### PR TITLE
Support session change commitments

### DIFF
--- a/primitives/src/commitment.rs
+++ b/primitives/src/commitment.rs
@@ -22,7 +22,7 @@ use core::cmp;
 /// The commitment contains a [payload] extracted from the finalized block at height [block_number].
 /// GRANDPA validators collect signatures on commitments and a stream of such signed commitments
 /// (see [SignedCommitment]) forms the BEEFY protocol.
-#[derive(Debug, PartialEq, Eq, codec::Encode, codec::Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, codec::Encode, codec::Decode)]
 pub struct Commitment<TBlockNumber, TPayload> {
 	/// The payload being signed.
 	///
@@ -82,7 +82,7 @@ where
 ///
 /// Importing [Commitment]s of particular kind may require additional actions to be taken by the
 /// client.
-#[derive(Debug, PartialEq, Eq, codec::Encode, codec::Decode)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, codec::Encode, codec::Decode)]
 pub enum CommitmentKind {
 	/// Regular commitment.
 	///
@@ -108,7 +108,7 @@ pub enum CommitmentKind {
 }
 
 /// A commitment with matching GRANDPA validators' signatures.
-#[derive(Debug, PartialEq, Eq, codec::Encode, codec::Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, codec::Encode, codec::Decode)]
 pub struct SignedCommitment<TBlockNumber, TPayload, TSignature> {
 	/// The commitment signatures are collected for.
 	pub commitment: Commitment<TBlockNumber, TPayload>,
@@ -152,7 +152,7 @@ mod tests {
 		assert_eq!(decoded, Ok(commitment));
 		assert_eq!(
 			encoded,
-			hex_literal::hex!("3048656c6c6f20576f726c642105000000000000000000000000000000000000000000000000")
+			hex_literal::hex!("3048656c6c6f20576f726c642105000000000000000000000000000000000000000000000002")
 		);
 	}
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -35,4 +35,4 @@ pub mod witness;
 /// A typedef for validator set id.
 pub type ValidatorSetId = u64;
 
-pub use commitment::{Commitment, SignedCommitment};
+pub use commitment::{Commitment, SignedCommitment, CommitmentKind};

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -35,4 +35,4 @@ pub mod witness;
 /// A typedef for validator set id.
 pub type ValidatorSetId = u64;
 
-pub use commitment::{Commitment, SignedCommitment, CommitmentKind};
+pub use commitment::{Commitment, CommitmentKind, SignedCommitment};

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -79,8 +79,8 @@ impl<TBlockNumber, TPayload, TMerkleRoot> SignedCommitmentWitness<TBlockNumber, 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use codec::Decode;
 	use crate::commitment::CommitmentKind;
+	use codec::Decode;
 
 	type TestCommitment = Commitment<u128, String>;
 	type TestSignedCommitment = SignedCommitment<u128, String, Vec<u8>>;

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -80,6 +80,7 @@ impl<TBlockNumber, TPayload, TMerkleRoot> SignedCommitmentWitness<TBlockNumber, 
 mod tests {
 	use super::*;
 	use codec::Decode;
+	use crate::commitment::CommitmentKind;
 
 	type TestCommitment = Commitment<u128, String>;
 	type TestSignedCommitment = SignedCommitment<u128, String, Vec<u8>>;

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -90,7 +90,7 @@ mod tests {
 			payload: "Hello World!".into(),
 			block_number: 5,
 			validator_set_id: 0,
-			is_set_transition_block: false,
+			kind: CommitmentKind::Regular,
 		};
 
 		SignedCommitment {

--- a/primitives/tests/basic_lc_operations.rs
+++ b/primitives/tests/basic_lc_operations.rs
@@ -115,7 +115,28 @@ fn light_client_should_reject_set_transitions_without_validator_proof() {
 			payload: Payload::new(1),
 			block_number: 1,
 			validator_set_id: 0,
-			kind: CommitmentKind::Regular,
+			kind: CommitmentKind::ValidatorSetTransition,
+		},
+		signatures: vec![Some(validator_set::Signature::ValidFor(0.into()))],
+	});
+
+	// then
+	assert_eq!(result, Err(Error::InvalidValidatorSetProof));
+	assert_eq!(lc.last_commitment(), None);
+}
+
+#[test]
+fn light_client_should_reject_session_transitions_without_validator_proof() {
+	// given
+	let mut lc = light_client::new();
+
+	// when
+	let result = lc.import(SignedCommitment {
+		commitment: Commitment {
+			payload: Payload::new(1),
+			block_number: 1,
+			validator_set_id: 0,
+			kind: CommitmentKind::SessionTransition,
 		},
 		signatures: vec![Some(validator_set::Signature::ValidFor(0.into()))],
 	});
@@ -279,7 +300,7 @@ fn light_client_should_perform_set_transition() {
 	};
 
 	// when
-	let result = lc.import_set_transition(
+	let result = lc.import_transition(
 		commitment,
 		light_client::merkle_tree::Proof::ValidFor(2.into(), vec![0.into(), 1.into(), 2.into()]),
 	);
@@ -308,7 +329,7 @@ fn light_client_reject_set_transition_with_invalid_payload() {
 	};
 
 	// when
-	let result = lc.import_set_transition(
+	let result = lc.import_transition(
 		commitment,
 		light_client::merkle_tree::Proof::ValidFor(2.into(), vec![0.into(), 1.into(), 2.into()]),
 	);
@@ -335,7 +356,7 @@ fn light_client_reject_set_transition_with_invalid_proof() {
 	};
 
 	// when
-	let result = lc.import_set_transition(
+	let result = lc.import_transition(
 		commitment,
 		light_client::merkle_tree::Proof::ValidFor(2.into(), vec![0.into(), 1.into(), 2.into()]),
 	);
@@ -362,7 +383,7 @@ fn light_client_should_perform_session_change() {
 	};
 
 	// when
-	let result = lc.import_set_transition(
+	let result = lc.import_transition(
 		commitment,
 		light_client::merkle_tree::Proof::ValidFor(2.into(), vec![0.into(), 1.into(), 2.into()]),
 	);

--- a/primitives/tests/basic_lc_operations.rs
+++ b/primitives/tests/basic_lc_operations.rs
@@ -16,9 +16,7 @@
 
 mod light_client;
 
-use self::light_client::{
-	validator_set, Commitment, Error, Payload, SignedCommitment, CommitmentKind,
-};
+use self::light_client::{validator_set, Commitment, CommitmentKind, Error, Payload, SignedCommitment};
 
 #[test]
 fn light_client_should_make_progress() {
@@ -373,4 +371,3 @@ fn light_client_should_perform_session_change() {
 	assert_eq!(result, Ok(()));
 	assert_eq!(lc.validator_set(), &(0, vec![0.into(), 1.into(), 2.into()],));
 }
-

--- a/primitives/tests/light_client/mod.rs
+++ b/primitives/tests/light_client/mod.rs
@@ -95,7 +95,7 @@ pub struct LightClient {
 
 impl LightClient {
 	pub fn import(&mut self, signed: SignedCommitment) -> Result<(), Error> {
-		// Make sure it's not a set transition block (see [import_set_transition]).
+		// Make sure it's not a set transition block (see [import_transition]).
 		if signed.commitment.kind != CommitmentKind::Regular {
 			return Err(Error::InvalidValidatorSetProof);
 		}
@@ -112,7 +112,8 @@ impl LightClient {
 		validator_set_proof: merkle_tree::Proof<ValidatorSetTree, Vec<validator_set::Public>>,
 	) -> Result<(), Error> {
 		// Make sure it is a set transition block (see [import]).
-		if let CommitmentKind::Regular = signed.commitment.kind {
+		let kind = signed.commitment.kind;
+		if let CommitmentKind::Regular = kind {
 			return Err(Error::InvalidValidatorSetProof);
 		}
 
@@ -129,7 +130,7 @@ impl LightClient {
 		}
 
 		let set = validator_set_proof.into_data();
-		let new_id = match signed.commitment.kind {
+		let new_id = match kind {
 			CommitmentKind::ValidatorSetTransition => self.validator_set.0 + 1,
 			CommitmentKind::SessionTransition | bp::CommitmentKind::Regular => self.validator_set.0,
 		};


### PR DESCRIPTION
Ideally BEEFY keys should not change every session (see #9), but for now we will create a special kind of commitment which only indicates that the session keys are updated.

@andresilva I'm actually not sure if we really need this - from BEEFY perspective there isn't really any difference between changing the validator set and only changing public keys, I think we might safely use substrate's session index as `Commitment::validator_set_id`. The only drawback is that set ids won't match between GRANDPA and BEEFY, but does it really matter?

Closes: #14 
