### PR TITLE
Add ValidatorSetId to BEEFY digest

### DIFF
--- a/beefy-pallet/src/lib.rs
+++ b/beefy-pallet/src/lib.rs
@@ -105,8 +105,14 @@ impl<T: Config> Pallet<T> {
 			let next = Self::validator_set_id() + 1u64;
 			<ValidatorSetId<T>>::put(next);
 
-			let log: DigestItem<T::Hash> =
-				DigestItem::Consensus(BEEFY_ENGINE_ID, ConsensusLog::AuthoritiesChange((new, next)).encode());
+			let log: DigestItem<T::Hash> = DigestItem::Consensus(
+				BEEFY_ENGINE_ID,
+				ConsensusLog::AuthoritiesChange {
+					new_validator_set: new,
+					new_validator_set_id: next,
+				}
+				.encode(),
+			);
 			<frame_system::Module<T>>::deposit_log(log);
 		}
 

--- a/beefy-pallet/src/lib.rs
+++ b/beefy-pallet/src/lib.rs
@@ -101,9 +101,12 @@ impl<T: Config> Pallet<T> {
 		// set has actually changed.
 		if new != Self::authorities() {
 			<Authorities<T>>::put(&new);
-			<ValidatorSetId<T>>::put(Self::validator_set_id() + 1);
+
+			let next = Self::validator_set_id() + 1u64;
+			<ValidatorSetId<T>>::put(next);
+
 			let log: DigestItem<T::Hash> =
-				DigestItem::Consensus(BEEFY_ENGINE_ID, ConsensusLog::AuthoritiesChange(new).encode());
+				DigestItem::Consensus(BEEFY_ENGINE_ID, ConsensusLog::AuthoritiesChange((new, next)).encode());
 			<frame_system::Module<T>>::deposit_log(log);
 		}
 

--- a/beefy-pallet/src/tests.rs
+++ b/beefy-pallet/src/tests.rs
@@ -69,10 +69,10 @@ fn session_change_updates_authorities() {
 
 		assert!(1 == Beefy::validator_set_id());
 
-		let want = beefy_log(ConsensusLog::AuthoritiesChange(vec![
-			mock_beefy_id(3),
-			mock_beefy_id(4),
-		]));
+		let want = beefy_log(ConsensusLog::AuthoritiesChange((
+			vec![mock_beefy_id(3), mock_beefy_id(4)],
+			1,
+		)));
 
 		let log = System::digest().logs[0].clone();
 

--- a/beefy-pallet/src/tests.rs
+++ b/beefy-pallet/src/tests.rs
@@ -69,10 +69,10 @@ fn session_change_updates_authorities() {
 
 		assert!(1 == Beefy::validator_set_id());
 
-		let want = beefy_log(ConsensusLog::AuthoritiesChange((
-			vec![mock_beefy_id(3), mock_beefy_id(4)],
-			1,
-		)));
+		let want = beefy_log(ConsensusLog::AuthoritiesChange {
+			new_validator_set: vec![mock_beefy_id(3), mock_beefy_id(4)],
+			new_validator_set_id: 1,
+		});
 
 		let log = System::digest().logs[0].clone();
 

--- a/beefy-primitives/src/lib.rs
+++ b/beefy-primitives/src/lib.rs
@@ -80,7 +80,12 @@ pub type MmrRootHash = H256;
 pub enum ConsensusLog<AuthorityId: Codec> {
 	/// The authorities have changed.
 	#[codec(index = 1)]
-	AuthoritiesChange((Vec<AuthorityId>, ValidatorSetId)),
+	AuthoritiesChange {
+		/// Set of new validators to be used
+		new_validator_set: Vec<AuthorityId>,
+		/// Id for this new set of validators
+		new_validator_set_id: ValidatorSetId,
+	},
 	/// Disable the authority with given index.
 	#[codec(index = 2)]
 	OnDisabled(AuthorityIndex),

--- a/beefy-primitives/src/lib.rs
+++ b/beefy-primitives/src/lib.rs
@@ -80,7 +80,7 @@ pub type MmrRootHash = H256;
 pub enum ConsensusLog<AuthorityId: Codec> {
 	/// The authorities have changed.
 	#[codec(index = 1)]
-	AuthoritiesChange(Vec<AuthorityId>),
+	AuthoritiesChange((Vec<AuthorityId>, ValidatorSetId)),
 	/// Disable the authority with given index.
 	#[codec(index = 2)]
 	OnDisabled(AuthorityIndex),


### PR DESCRIPTION
Adding `ValidatorSetId` to the BEEFY digest will allow for easier validator set changes tracking within the BEEFY gadget.