### PR TITLE
Update toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on:                       ubuntu-latest
     env:
       RUST_BACKTRACE:   full
-      NIGHTLY: nightly-2020-10-04
+      NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
@@ -44,7 +44,7 @@ jobs:
     runs-on:                       ubuntu-latest
     env:
       RUST_BACKTRACE:   full
-      NIGHTLY: nightly-2020-10-04
+      NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
@@ -80,7 +80,7 @@ jobs:
     runs-on:                       ubuntu-latest
     env:
       RUST_BACKTRACE:   full
-      NIGHTLY: nightly-2020-10-04
+      NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
@@ -102,5 +102,5 @@ jobs:
         uses:                      actions-rs/cargo@master
         with:
           command:                 clippy
-          toolchain:               nightly-2020-10-04
+          toolchain:               nightly
           args:                    --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth:             5
           submodules:              recursive
       - name:                      Install Toolchain
-        run:                       rustup toolchain add $NIGHTLY
+        run:                       rustup toolchain add nightly
       - name:                      Add WASM Utilities
         run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
 ## Check Stage
@@ -90,7 +90,7 @@ jobs:
           fetch-depth:             5
           submodules:              recursive
       - name:                      Install Toolchain
-        run:                       rustup toolchain add $NIGHTLY
+        run:                       rustup toolchain add nightly
       - name:                      Add WASM Utilities
         run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
 ## Linting Stage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,5 +102,5 @@ jobs:
         uses:                      actions-rs/cargo@master
         with:
           command:                 clippy
-          toolchain:               nightly-2020-10-04
+          toolchain:               nightly
           args:                    --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on:                       ubuntu-latest
     env:
       RUST_BACKTRACE:   full
-      NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
@@ -30,7 +29,7 @@ jobs:
       - name:                      Install Toolchain
         run:                       rustup toolchain add stable
       - name:                      Add WASM Utilities
-        run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
+        run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
 ## Build Stage
       - name:                      Building rust-stable
         uses:                      actions-rs/cargo@master
@@ -45,7 +44,6 @@ jobs:
     runs-on:                       ubuntu-latest
     env:
       RUST_BACKTRACE:   full
-      NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
@@ -59,7 +57,7 @@ jobs:
       - name:                      Install Toolchain
         run:                       rustup toolchain add stable
       - name:                      Add WASM Utilities
-        run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
+        run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
 ## Check Stage
       - name:                      Checking rust-stable
         uses:                      actions-rs/cargo@master

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,13 +9,13 @@ on:
       - v*
     paths-ignore:
       - 'README.md'
-      - docs/*
 jobs:
   build:
     name:                          Build
     runs-on:                       ubuntu-latest
     env:
       RUST_BACKTRACE:   full
+      NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
@@ -27,9 +27,9 @@ jobs:
           fetch-depth:             5
           submodules:              recursive
       - name:                      Install Toolchain
-        run:                       rustup toolchain add nightly
+        run:                       rustup toolchain add $NIGHTLY
       - name:                      Add WASM Utilities
-        run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
+        run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
 ## Build Stage
       - name:                      Building rust-stable
         uses:                      actions-rs/cargo@master
@@ -44,6 +44,7 @@ jobs:
     runs-on:                       ubuntu-latest
     env:
       RUST_BACKTRACE:   full
+      NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
@@ -55,12 +56,12 @@ jobs:
           fetch-depth:             5
           submodules:              recursive
       - name:                      Install Toolchain
-        run:                       rustup toolchain add nightly
+        run:                       rustup toolchain add $NIGHTLY
       - name:                      Add WASM Utilities
-        run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
+        run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
 ## Check Stage
       - name:                      Checking rust-stable
-        uses:                      actions-r$NIGHTLY/cargo@master
+        uses:                      actions-rs/cargo@master
         with:
           command:                 check
           toolchain:               stable
@@ -79,6 +80,7 @@ jobs:
     runs-on:                       ubuntu-latest
     env:
       RUST_BACKTRACE:   full
+      NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
@@ -90,15 +92,15 @@ jobs:
           fetch-depth:             5
           submodules:              recursive
       - name:                      Install Toolchain
-        run:                       rustup toolchain add nightly
+        run:                       rustup toolchain add $NIGHTLY
       - name:                      Add WASM Utilities
-        run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
+        run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
 ## Linting Stage
       - name:                      Add clippy
-        run:                       rustup component add clippy --toolchain nightly
+        run:                       rustup component add clippy --toolchain $NIGHTLY
       - name:                      Clippy
         uses:                      actions-rs/cargo@master
         with:
           command:                 clippy
-          toolchain:               nightly
+          toolchain:               nightly-2020-10-04
           args:                    --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth:             5
           submodules:              recursive
       - name:                      Install Toolchain
-        run:                       rustup toolchain add $NIGHTLY
+        run:                       rustup toolchain add stable
       - name:                      Add WASM Utilities
         run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
 ## Build Stage
@@ -57,7 +57,7 @@ jobs:
           fetch-depth:             5
           submodules:              recursive
       - name:                      Install Toolchain
-        run:                       rustup toolchain add
+        run:                       rustup toolchain add stable
       - name:                      Add WASM Utilities
         run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
 ## Check Stage
@@ -92,7 +92,7 @@ jobs:
           fetch-depth:             5
           submodules:              recursive
       - name:                      Install Toolchain
-        run:                       rustup toolchain add
+        run:                       rustup toolchain add stable
       - name:                      Add WASM Utilities
         run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
 ## Linting Stage
@@ -102,4 +102,5 @@ jobs:
         uses:                      actions-rs/cargo@master
         with:
           command:                 clippy
+          toolchain:               stable
           args:                    --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,5 +102,5 @@ jobs:
         uses:                      actions-rs/cargo@master
         with:
           command:                 clippy
-          toolchain:               nightly
+          toolchain:               
           args:                    --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,97 +8,130 @@ on:
     tags:
       - v*
     paths-ignore:
-      - 'README.md'
+      - '**.md'
       - docs/*
 jobs:
-  build:
-    name:                          Build
+
+## Check Stage
+  check-test:
+    name:                          Check and test
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          #- beta
+          - nightly
     runs-on:                       ubuntu-latest
     env:
-      RUST_BACKTRACE:   full
+      RUST_BACKTRACE:              full
+      NIGHTLY:                     nightly #if necessary, specify the version, nightly-2020-10-04, etc.
     steps:
+      
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
         with:
           access_token:            ${{ github.token }}
+      
       - name:                      Checkout sources & submodules
         uses:                      actions/checkout@master
         with:
           fetch-depth:             5
           submodules:              recursive
+      
       - name:                      Install Toolchain
-        run:                       rustup toolchain add stable
+        run:                       rustup toolchain add $NIGHTLY
+      
       - name:                      Add WASM Utilities
-        run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
+        run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
+      
+      - name:                      Checking rust-${{ matrix.toolchain }}
+        uses:                      actions-rs/cargo@master
+        with:
+          command:                 check
+          toolchain:               ${{ matrix.toolchain }}
+          args:                    --all  --verbose
+
+## Test Stage
+      - name:                      Testing rust-${{ matrix.toolchain }}
+        uses:                      actions-rs/cargo@master
+        if:                        matrix.toolchain == 'stable'
+        with:
+          command:                 test
+          toolchain:               ${{ matrix.toolchain }}
+          args:                    --all  --verbose
+
 ## Build Stage
-      - name:                      Building rust-stable
+  build:
+    name:                          Build
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          #- beta
+          - nightly
+    runs-on:                       ubuntu-latest
+    env:
+      RUST_BACKTRACE:              full
+      NIGHTLY:                     nightly #if necessary, specify the version, nightly-2020-10-04, etc.
+    steps:
+      
+      - name:                      Cancel Previous Runs
+        uses:                      styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token:            ${{ github.token }}
+      
+      - name:                      Checkout sources & submodules
+        uses:                      actions/checkout@master
+        with:
+          fetch-depth:             5
+          submodules:              recursive
+      
+      - name:                      Install Toolchain
+        run:                       rustup toolchain add $NIGHTLY
+      
+      - name:                      Add WASM Utilities
+        run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
+      
+      - name:                      Building rust-${{ matrix.toolchain }}
         uses:                      actions-rs/cargo@master
         if:                        github.ref == 'refs/heads/master'
         with:
           command:                 build
-          toolchain:               stable
-          args:                    --all --release --verbose
-
-  check-test:
-    name:                          Check and test
-    runs-on:                       ubuntu-latest
-    env:
-      RUST_BACKTRACE:   full
-    steps:
-      - name:                      Cancel Previous Runs
-        uses:                      styfle/cancel-workflow-action@0.4.1
-        with:
-          access_token:            ${{ github.token }}
-      - name:                      Checkout sources & submodules
-        uses:                      actions/checkout@master
-        with:
-          fetch-depth:             5
-          submodules:              recursive
-      - name:                      Install Toolchain
-        run:                       rustup toolchain add stable
-      - name:                      Add WASM Utilities
-        run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
-## Check Stage
-      - name:                      Checking rust-stable
-        uses:                      actions-rs/cargo@master
-        with:
-          command:                 check
-          toolchain:               stable
-          args:                    --all  --verbose
-
-## Test Stage
-      - name:                      Testing rust-stable
-        uses:                      actions-rs/cargo@master
-        with:
-          command:                 test
-          toolchain:               stable
-          args:                    --all  --verbose
-
+          toolchain:               ${{ matrix.toolchain }}
+          args:                    --all --verbose
+      
+ ## Linting Stage
   clippy:
     name:                          Clippy
     runs-on:                       ubuntu-latest
     env:
-      RUST_BACKTRACE:   full
+      RUST_BACKTRACE:              full
+      NIGHTLY:                     nightly #if necessary, specify the version, nightly-2020-10-04, etc.
     steps:
+
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
         with:
           access_token:            ${{ github.token }}
+      
       - name:                      Checkout sources & submodules
         uses:                      actions/checkout@master
         with:
           fetch-depth:             5
           submodules:              recursive
+      
       - name:                      Install Toolchain
-        run:                       rustup toolchain add stable
+        run:                       rustup toolchain add $NIGHTLY
+      
       - name:                      Add WASM Utilities
-        run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
-## Linting Stage
+        run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
+      
       - name:                      Add clippy
-        run:                       rustup component add clippy
+        run:                       rustup component add clippy --toolchain $NIGHTLY
+            
       - name:                      Clippy
         uses:                      actions-rs/cargo@master
         with:
           command:                 clippy
-          toolchain:               stable
+          toolchain:               nightly #if necessary, specify the version, nightly-2020-10-04, etc.
           args:                    --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,7 @@ jobs:
     runs-on:                       ubuntu-latest
     env:
       RUST_BACKTRACE:   full
+      NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,7 +80,6 @@ jobs:
     runs-on:                       ubuntu-latest
     env:
       RUST_BACKTRACE:   full
-      NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
@@ -102,5 +101,5 @@ jobs:
         uses:                      actions-rs/cargo@master
         with:
           command:                 clippy
-          toolchain:               
+          toolchain:               stable
           args:                    --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on:                       ubuntu-latest
     env:
       RUST_BACKTRACE:   full
-      NIGHTLY: nightly
+      NIGHTLY: stable
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,7 @@ on:
       - v*
     paths-ignore:
       - 'README.md'
+      - docs/*
 jobs:
   build:
     name:                          Build
@@ -56,7 +57,7 @@ jobs:
           fetch-depth:             5
           submodules:              recursive
       - name:                      Install Toolchain
-        run:                       rustup toolchain add $NIGHTLY
+        run:                       rustup toolchain add
       - name:                      Add WASM Utilities
         run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
 ## Check Stage
@@ -80,7 +81,6 @@ jobs:
     runs-on:                       ubuntu-latest
     env:
       RUST_BACKTRACE:   full
-      NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
@@ -92,12 +92,12 @@ jobs:
           fetch-depth:             5
           submodules:              recursive
       - name:                      Install Toolchain
-        run:                       rustup toolchain add $NIGHTLY
+        run:                       rustup toolchain add
       - name:                      Add WASM Utilities
-        run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
+        run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
 ## Linting Stage
       - name:                      Add clippy
-        run:                       rustup component add clippy --toolchain $NIGHTLY
+        run:                       rustup component add clippy
       - name:                      Clippy
         uses:                      actions-rs/cargo@master
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on:                       ubuntu-latest
     env:
       RUST_BACKTRACE:   full
-      NIGHTLY: stable
+      NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
@@ -102,5 +102,4 @@ jobs:
         uses:                      actions-rs/cargo@master
         with:
           command:                 clippy
-          toolchain:               stable
           args:                    --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,130 +8,97 @@ on:
     tags:
       - v*
     paths-ignore:
-      - '**.md'
+      - 'README.md'
       - docs/*
 jobs:
-
-## Check Stage
-  check-test:
-    name:                          Check and test
-    strategy:
-      matrix:
-        toolchain:
-          - stable
-          #- beta
-          - nightly
-    runs-on:                       ubuntu-latest
-    env:
-      RUST_BACKTRACE:              full
-      NIGHTLY:                     nightly #if necessary, specify the version, nightly-2020-10-04, etc.
-    steps:
-      
-      - name:                      Cancel Previous Runs
-        uses:                      styfle/cancel-workflow-action@0.4.1
-        with:
-          access_token:            ${{ github.token }}
-      
-      - name:                      Checkout sources & submodules
-        uses:                      actions/checkout@master
-        with:
-          fetch-depth:             5
-          submodules:              recursive
-      
-      - name:                      Install Toolchain
-        run:                       rustup toolchain add $NIGHTLY
-      
-      - name:                      Add WASM Utilities
-        run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
-      
-      - name:                      Checking rust-${{ matrix.toolchain }}
-        uses:                      actions-rs/cargo@master
-        with:
-          command:                 check
-          toolchain:               ${{ matrix.toolchain }}
-          args:                    --all  --verbose
-
-## Test Stage
-      - name:                      Testing rust-${{ matrix.toolchain }}
-        uses:                      actions-rs/cargo@master
-        if:                        matrix.toolchain == 'stable'
-        with:
-          command:                 test
-          toolchain:               ${{ matrix.toolchain }}
-          args:                    --all  --verbose
-
-## Build Stage
   build:
     name:                          Build
-    strategy:
-      matrix:
-        toolchain:
-          - stable
-          #- beta
-          - nightly
     runs-on:                       ubuntu-latest
     env:
-      RUST_BACKTRACE:              full
-      NIGHTLY:                     nightly #if necessary, specify the version, nightly-2020-10-04, etc.
+      RUST_BACKTRACE:   full
     steps:
-      
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
         with:
           access_token:            ${{ github.token }}
-      
       - name:                      Checkout sources & submodules
         uses:                      actions/checkout@master
         with:
           fetch-depth:             5
           submodules:              recursive
-      
       - name:                      Install Toolchain
-        run:                       rustup toolchain add $NIGHTLY
-      
+        run:                       rustup toolchain add nightly
       - name:                      Add WASM Utilities
-        run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
-      
-      - name:                      Building rust-${{ matrix.toolchain }}
+        run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
+## Build Stage
+      - name:                      Building rust-stable
         uses:                      actions-rs/cargo@master
         if:                        github.ref == 'refs/heads/master'
         with:
           command:                 build
-          toolchain:               ${{ matrix.toolchain }}
-          args:                    --all --verbose
-      
- ## Linting Stage
-  clippy:
-    name:                          Clippy
+          toolchain:               stable
+          args:                    --all --release --verbose
+
+  check-test:
+    name:                          Check and test
     runs-on:                       ubuntu-latest
     env:
-      RUST_BACKTRACE:              full
-      NIGHTLY:                     nightly #if necessary, specify the version, nightly-2020-10-04, etc.
+      RUST_BACKTRACE:   full
     steps:
-
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
         with:
           access_token:            ${{ github.token }}
-      
       - name:                      Checkout sources & submodules
         uses:                      actions/checkout@master
         with:
           fetch-depth:             5
           submodules:              recursive
-      
       - name:                      Install Toolchain
         run:                       rustup toolchain add $NIGHTLY
-      
       - name:                      Add WASM Utilities
-        run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
-      
+        run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
+## Check Stage
+      - name:                      Checking rust-stable
+        uses:                      actions-r$NIGHTLY/cargo@master
+        with:
+          command:                 check
+          toolchain:               stable
+          args:                    --all  --verbose
+
+## Test Stage
+      - name:                      Testing rust-stable
+        uses:                      actions-rs/cargo@master
+        with:
+          command:                 test
+          toolchain:               stable
+          args:                    --all  --verbose
+
+  clippy:
+    name:                          Clippy
+    runs-on:                       ubuntu-latest
+    env:
+      RUST_BACKTRACE:   full
+    steps:
+      - name:                      Cancel Previous Runs
+        uses:                      styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token:            ${{ github.token }}
+      - name:                      Checkout sources & submodules
+        uses:                      actions/checkout@master
+        with:
+          fetch-depth:             5
+          submodules:              recursive
+      - name:                      Install Toolchain
+        run:                       rustup toolchain add $NIGHTLY
+      - name:                      Add WASM Utilities
+        run:                       rustup target add wasm32-unknown-unknown --toolchain nightly
+## Linting Stage
       - name:                      Add clippy
-        run:                       rustup component add clippy --toolchain $NIGHTLY
-            
+        run:                       rustup component add clippy --toolchain nightly
       - name:                      Clippy
         uses:                      actions-rs/cargo@master
         with:
           command:                 clippy
-          toolchain:               nightly #if necessary, specify the version, nightly-2020-10-04, etc.
+          toolchain:               nightly
           args:                    --all-targets -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "substrate-wasm-builder-runner",
+ "substrate-wasm-builder",
 ]
 
 [[package]]
@@ -741,6 +741,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-helper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdce191bf3fa4995ce948c8c83b4640a1745457a149e73c6db75b4ffe36aad5f"
+dependencies = [
+ "semver 0.6.0",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +801,28 @@ name = "cache-padded"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714a157da7991e23d90686b9524b9e12e0407a108647f52e9328f4b3d51ac7f"
+dependencies = [
+ "cargo-platform",
+ "semver 0.11.0",
+ "semver-parser 0.10.2",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cc"
@@ -4129,6 +4160,15 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ad52817c4d343339b3bc2e26861bd21478eda0b7509acf83505727000512ac"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
@@ -4611,7 +4651,7 @@ checksum = "0f53bc2558e8376358ebdc28301546471d67336584f6438ed4b7c7457a055fd7"
 dependencies = [
  "byteorder",
  "log",
- "parity-wasm",
+ "parity-wasm 0.41.0",
 ]
 
 [[package]]
@@ -5034,7 +5074,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -5108,6 +5148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399f290ffc409596022fce5ea5d4138184be4784f2b28c62c59f0d8389059a15"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -5435,7 +5484,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "parity-wasm",
+ "parity-wasm 0.41.0",
  "parking_lot 0.11.1",
  "sc-executor-common",
  "sc-executor-wasmi",
@@ -5461,7 +5510,7 @@ source = "git+https://github.com/paritytech/substrate?branch=master#88014d553fc1
 dependencies = [
  "derive_more",
  "parity-scale-codec",
- "parity-wasm",
+ "parity-wasm 0.41.0",
  "sp-allocator",
  "sp-core",
  "sp-serializer",
@@ -5492,7 +5541,7 @@ source = "git+https://github.com/paritytech/substrate?branch=master#88014d553fc1
 dependencies = [
  "log",
  "parity-scale-codec",
- "parity-wasm",
+ "parity-wasm 0.41.0",
  "pwasm-utils",
  "sc-executor-common",
  "scoped-tls",
@@ -6085,11 +6134,30 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
+dependencies = [
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
+ "serde",
 ]
 
 [[package]]
@@ -6097,6 +6165,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -7073,10 +7150,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-wasm-builder-runner"
-version = "2.0.0"
+name = "substrate-wasm-builder"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cab12167e32b38a62c5ea5825aa0874cde315f907a46aad2b05aa8ef3d862f"
+checksum = "93a3d51ad6abbc408b03ea962062bfcc959b438a318d7d4bedd181e1effd0610"
+dependencies = [
+ "ansi_term 0.12.1",
+ "atty",
+ "build-helper",
+ "cargo_metadata",
+ "tempfile",
+ "toml",
+ "walkdir",
+ "wasm-gc-api",
+]
 
 [[package]]
 name = "subtle"
@@ -7841,6 +7928,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7940,6 +8038,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
 
 [[package]]
+name = "wasm-gc-api"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c32691b6c7e6c14e7f8fd55361a9088b507aa49620fcd06c09b3a1082186b9"
+dependencies = [
+ "log",
+ "parity-wasm 0.32.0",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "wasm-timer"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7964,7 +8073,7 @@ dependencies = [
  "memory_units",
  "num-rational",
  "num-traits",
- "parity-wasm",
+ "parity-wasm 0.41.0",
  "wasmi-validation",
 ]
 
@@ -7974,7 +8083,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
 dependencies = [
- "parity-wasm",
+ "parity-wasm 0.41.0",
 ]
 
 [[package]]

--- a/beefy-cli/src/cli/utils.rs
+++ b/beefy-cli/src/cli/utils.rs
@@ -22,7 +22,7 @@ pub fn parse_hex(hex: &str) -> anyhow::Result<Vec<u8>> {
 	let s = if hex.starts_with("0x") {
 		&hex.as_bytes()[2..]
 	} else {
-		&hex.as_bytes()[..]
+		&hex.as_bytes()
 	};
 
 	Ok(hex::decode(s)?)

--- a/beefy-node/runtime/Cargo.toml
+++ b/beefy-node/runtime/Cargo.toml
@@ -11,7 +11,7 @@ version = "2.0.0"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "2.0.0" }
+substrate-wasm-builder = { version = "4.0.0" }
 
 # alias "parity-scale-code" to "codec"
 [dependencies.codec]

--- a/beefy-node/runtime/build.rs
+++ b/beefy-node/runtime/build.rs
@@ -1,9 +1,8 @@
-use wasm_builder_runner::WasmBuilder;
+use substrate_wasm_builder::WasmBuilder;
 
 fn main() {
 	WasmBuilder::new()
 		.with_current_project()
-		.with_wasm_builder_from_crates("2.0.0")
 		.export_heap_base()
 		.import_memory()
 		.build()

--- a/beefy-node/runtime/src/lib.rs
+++ b/beefy-node/runtime/src/lib.rs
@@ -5,6 +5,8 @@
 #![allow(clippy::large_enum_variant)]
 // Runtime-generated DecodeLimit::decode_all_With_depth_limit
 #![allow(clippy::unnecessary_mut_passed)]
+// construct_runtime requires this
+#![allow(clippy::from_over_into)]
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]

--- a/beefy-pallet/src/mock.rs
+++ b/beefy-pallet/src/mock.rs
@@ -14,17 +14,21 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+// construct_runtime requires this
+#![allow(clippy::from_over_into)]
+
 use std::vec;
 
-use frame_support::{parameter_types, sp_io::TestExternalities, BasicExternalities};
-
-use sp_core::H256;
-use sp_runtime::{
-	app_crypto::ecdsa::Public,
-	impl_opaque_keys,
-	testing::Header,
-	traits::{BlakeTwo256, ConvertInto, IdentityLookup, OpaqueKeys},
-	Perbill,
+use {
+	frame_support::{construct_runtime, parameter_types, sp_io::TestExternalities, BasicExternalities},
+	sp_core::H256,
+	sp_runtime::{
+		app_crypto::ecdsa::Public,
+		impl_opaque_keys,
+		testing::Header,
+		traits::{BlakeTwo256, ConvertInto, IdentityLookup, OpaqueKeys},
+		Perbill,
+	},
 };
 
 use crate as pallet_beefy;
@@ -40,7 +44,7 @@ impl_opaque_keys! {
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
-frame_support::construct_runtime!(
+construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,


### PR DESCRIPTION
Clippy for #114 fails due to an outdated version. We should be able to just use nightly.