### PR TITLE
Use wildcard for dep patch grouping

### DIFF
--- a/beefy-gadget/rpc/Cargo.toml
+++ b/beefy-gadget/rpc/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-futures = { version = "0.3.14", features = ["compat"] }
-log = "0.4"
-serde = { version = "1.0.125", features = ["derive"] }
-serde_json = "1.0.64"
+futures = { version = "0.3.*", features = ["compat"] }
+log = "0.4.*"
+serde = { version = "1.0.*", features = ["derive"] }
+serde_json = "1.0.*"
 
-jsonrpc-core = "15.1.0"
-jsonrpc-core-client = "15.1.0"
-jsonrpc-derive = "15.1.0"
-jsonrpc-pubsub = "15.1.0"
+jsonrpc-core = "15.1.*"
+jsonrpc-core-client = "15.1.*"
+jsonrpc-derive = "15.1.*"
+jsonrpc-pubsub = "15.1.*"
 
 codec = { version = "2.0.0", package = "parity-scale-codec", features = ["derive"] }
 

--- a/beefy-node/node/Cargo.toml
+++ b/beefy-node/node/Cargo.toml
@@ -19,8 +19,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [dependencies]
-jsonrpc-core = "15.0.0"
-structopt = "0.3.21"
+jsonrpc-core = "15.1.*"
+structopt = "0.3.*"
 
 # local dependencies
 beefy-primitives = { version = "0.1.0", path = "../../beefy-primitives" }

--- a/beefy-pallet/Cargo.toml
+++ b/beefy-pallet/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }
-serde = { version = "1.0.125", optional = true }
+serde = { version = "1.0.*", optional = true }
 
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }


### PR DESCRIPTION
Use wildcard to specify external Cargo dependencies. Specifically for the `patch` grouping. This allows for easier integration with external repositories, like Bridges.

Using Wildcards will also assure, that **only** the patch level version is upgraded, regardless of how a version string looks like.