### PR TITLE
Add block_delta parameter to start_beefy_gadget

### DIFF
--- a/beefy-gadget/src/lib.rs
+++ b/beefy-gadget/src/lib.rs
@@ -94,6 +94,7 @@ pub async fn start_beefy_gadget<B, P, BE, C, N, SO>(
 	network: N,
 	signed_commitment_sender: notification::BeefySignedCommitmentSender<B, P::Signature>,
 	_sync_oracle: SO,
+	block_delta: u32,
 	prometheus_registry: Option<Registry>,
 ) where
 	B: Block,
@@ -129,6 +130,7 @@ pub async fn start_beefy_gadget<B, P, BE, C, N, SO>(
 		signed_commitment_sender,
 		gossip_engine,
 		gossip_validator,
+		block_delta,
 		metrics,
 	);
 

--- a/beefy-gadget/src/lib.rs
+++ b/beefy-gadget/src/lib.rs
@@ -94,7 +94,7 @@ pub async fn start_beefy_gadget<B, P, BE, C, N, SO>(
 	network: N,
 	signed_commitment_sender: notification::BeefySignedCommitmentSender<B, P::Signature>,
 	_sync_oracle: SO,
-	block_delta: u32,
+	min_block_delta: u32,
 	prometheus_registry: Option<Registry>,
 ) where
 	B: Block,
@@ -130,7 +130,7 @@ pub async fn start_beefy_gadget<B, P, BE, C, N, SO>(
 		signed_commitment_sender,
 		gossip_engine,
 		gossip_validator,
-		block_delta,
+		min_block_delta,
 		metrics,
 	);
 

--- a/beefy-gadget/src/worker.rs
+++ b/beefy-gadget/src/worker.rs
@@ -67,10 +67,10 @@ where
 	signed_commitment_sender: notification::BeefySignedCommitmentSender<B, P::Signature>,
 	gossip_engine: Arc<Mutex<GossipEngine<B>>>,
 	gossip_validator: Arc<BeefyGossipValidator<B, P>>,
+	block_delta: u32,
 	metrics: Option<Metrics>,
 	rounds: round::Rounds<MmrRootHash, NumberFor<B>, P::Public, P::Signature>,
 	finality_notifications: FinalityNotifications<B>,
-	min_interval: u32,
 	/// Best block we received a GRANDPA notification for
 	best_grandpa_block: NumberFor<B>,
 	/// Best block a BEEFY voting round has been concluded for
@@ -103,6 +103,7 @@ where
 		signed_commitment_sender: notification::BeefySignedCommitmentSender<B, P::Signature>,
 		gossip_engine: GossipEngine<B>,
 		gossip_validator: Arc<BeefyGossipValidator<B, P>>,
+		block_delta: u32,
 		metrics: Option<Metrics>,
 	) -> Self {
 		BeefyWorker {
@@ -111,10 +112,10 @@ where
 			signed_commitment_sender,
 			gossip_engine: Arc::new(Mutex::new(gossip_engine)),
 			gossip_validator,
+			block_delta,
 			metrics,
 			rounds: round::Rounds::new(ValidatorSet::empty()),
 			finality_notifications: client.finality_notification_stream(),
-			min_interval: 2,
 			best_grandpa_block: client.info().finalized_number,
 			best_beefy_block: None,
 			best_block_voted_on: Zero::zero(),
@@ -148,7 +149,7 @@ where
 		let diff = self.best_grandpa_block.saturating_sub(best_beefy_block);
 		let diff = diff.saturated_into::<u32>();
 		let next_power_of_two = (diff / 2).next_power_of_two();
-		let next_block_to_vote_on = self.best_block_voted_on + self.min_interval.max(next_power_of_two).into();
+		let next_block_to_vote_on = self.best_block_voted_on + self.block_delta.max(next_power_of_two).into();
 
 		trace!(
 			target: "beefy",

--- a/beefy-gadget/src/worker.rs
+++ b/beefy-gadget/src/worker.rs
@@ -67,7 +67,7 @@ where
 	signed_commitment_sender: notification::BeefySignedCommitmentSender<B, P::Signature>,
 	gossip_engine: Arc<Mutex<GossipEngine<B>>>,
 	gossip_validator: Arc<BeefyGossipValidator<B, P>>,
-	block_delta: u32,
+	min_block_delta: u32,
 	metrics: Option<Metrics>,
 	rounds: round::Rounds<MmrRootHash, NumberFor<B>, P::Public, P::Signature>,
 	finality_notifications: FinalityNotifications<B>,
@@ -103,7 +103,7 @@ where
 		signed_commitment_sender: notification::BeefySignedCommitmentSender<B, P::Signature>,
 		gossip_engine: GossipEngine<B>,
 		gossip_validator: Arc<BeefyGossipValidator<B, P>>,
-		block_delta: u32,
+		min_block_delta: u32,
 		metrics: Option<Metrics>,
 	) -> Self {
 		BeefyWorker {
@@ -112,7 +112,7 @@ where
 			signed_commitment_sender,
 			gossip_engine: Arc::new(Mutex::new(gossip_engine)),
 			gossip_validator,
-			block_delta,
+			min_block_delta,
 			metrics,
 			rounds: round::Rounds::new(ValidatorSet::empty()),
 			finality_notifications: client.finality_notification_stream(),
@@ -149,7 +149,7 @@ where
 		let diff = self.best_grandpa_block.saturating_sub(best_beefy_block);
 		let diff = diff.saturated_into::<u32>();
 		let next_power_of_two = (diff / 2).next_power_of_two();
-		let next_block_to_vote_on = self.best_block_voted_on + self.block_delta.max(next_power_of_two).into();
+		let next_block_to_vote_on = self.best_block_voted_on + self.min_block_delta.max(next_power_of_two).into();
 
 		trace!(
 			target: "beefy",

--- a/beefy-node/node/src/service.rs
+++ b/beefy-node/node/src/service.rs
@@ -240,6 +240,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 			network.clone(),
 			signed_commitment_sender,
 			network.clone(),
+			4,
 			prometheus_registry.clone(),
 		),
 	);


### PR DESCRIPTION
`min_block_delta` determines the minimum delta in block numbers between two blocks, BEEFY should vote on. This parameter has been exposed to the public interface so that it could be configured differently for different chains.

The reason why you might want different block deltas for different chains is that a larger block delta will result in **less** gossip messages from BEEFY. 