### PR TITLE
Fix should_vote_on()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "sc-network-gossip",
  "sp-api",
  "sp-application-crypto",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",

--- a/beefy-gadget/Cargo.toml
+++ b/beefy-gadget/Cargo.toml
@@ -17,6 +17,7 @@ prometheus = { package = "substrate-prometheus-endpoint", git = "https://github.
 
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/beefy-gadget/src/worker.rs
+++ b/beefy-gadget/src/worker.rs
@@ -32,11 +32,12 @@ use sc_network_gossip::GossipEngine;
 
 use sp_api::BlockId;
 use sp_application_crypto::{AppPublic, Public};
+use sp_arithmetic::traits::AtLeast32Bit;
 use sp_core::Pair;
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 use sp_runtime::{
 	generic::OpaqueDigestItemId,
-	traits::{Block, Header, NumberFor, Saturating},
+	traits::{Block, Header, NumberFor},
 	SaturatedConversion,
 };
 
@@ -147,7 +148,7 @@ where
 			return false;
 		};
 
-		let target = vote_target::<B>(self.best_grandpa_block, best_beefy_block, self.min_block_delta);
+		let target = vote_target(self.best_grandpa_block, best_beefy_block, self.min_block_delta);
 
 		trace!(target: "beefy", "🥩 should_vote_on: #{:?}, next_block_to_vote_on: #{:?}", number, target);
 
@@ -388,9 +389,9 @@ where
 }
 
 /// Calculate next block number to vote on
-fn vote_target<N>(best_grandpa: NumberFor<N>, best_beefy: NumberFor<N>, min_delta: u32) -> NumberFor<N>
+fn vote_target<N>(best_grandpa: N, best_beefy: N, min_delta: u32) -> N
 where
-	N: Block,
+	N: AtLeast32Bit + Copy + Debug,
 {
 	let diff = best_grandpa.saturating_sub(best_beefy);
 	let diff = diff.saturated_into::<u32>();
@@ -410,100 +411,92 @@ where
 #[cfg(test)]
 mod tests {
 	use super::vote_target;
-	use sp_api::NumberFor;
-	use sp_runtime::testing::{Block, ExtrinsicWrapper};
-
-	type MockBlock = Block<ExtrinsicWrapper<u64>>;
-
-	fn block(num: u32) -> NumberFor<MockBlock> {
-		num.into()
-	}
 
 	#[test]
 	fn vote_on_min_block_delta() {
-		let t = vote_target::<MockBlock>(block(1), block(0), 4);
+		let t = vote_target(1u32, 0, 4);
 		assert_eq!(4, t);
-		let t = vote_target::<MockBlock>(block(2), block(0), 4);
+		let t = vote_target(2u32, 0, 4);
 		assert_eq!(4, t);
-		let t = vote_target::<MockBlock>(block(3), block(0), 4);
+		let t = vote_target(3u32, 0, 4);
 		assert_eq!(4, t);
-		let t = vote_target::<MockBlock>(block(4), block(0), 4);
+		let t = vote_target(4u32, 0, 4);
 		assert_eq!(4, t);
 
-		let t = vote_target::<MockBlock>(block(4), block(4), 4);
+		let t = vote_target(4u32, 4, 4);
 		assert_eq!(8, t);
 
-		let t = vote_target::<MockBlock>(block(10), block(10), 4);
+		let t = vote_target(10u32, 10, 4);
 		assert_eq!(14, t);
-		let t = vote_target::<MockBlock>(block(11), block(10), 4);
+		let t = vote_target(11u32, 10, 4);
 		assert_eq!(14, t);
-		let t = vote_target::<MockBlock>(block(12), block(10), 4);
+		let t = vote_target(12u32, 10, 4);
 		assert_eq!(14, t);
-		let t = vote_target::<MockBlock>(block(13), block(10), 4);
+		let t = vote_target(13u32, 10, 4);
 		assert_eq!(14, t);
 
-		let t = vote_target::<MockBlock>(block(10), block(10), 8);
+		let t = vote_target(10u32, 10, 8);
 		assert_eq!(18, t);
-		let t = vote_target::<MockBlock>(block(11), block(10), 8);
+		let t = vote_target(11u32, 10, 8);
 		assert_eq!(18, t);
-		let t = vote_target::<MockBlock>(block(12), block(10), 8);
+		let t = vote_target(12u32, 10, 8);
 		assert_eq!(18, t);
-		let t = vote_target::<MockBlock>(block(13), block(10), 8);
+		let t = vote_target(13u32, 10, 8);
 		assert_eq!(18, t);
 	}
 
 	#[test]
 	fn vote_on_power_of_two() {
-		let t = vote_target::<MockBlock>(block(1008), block(1000), 4);
+		let t = vote_target(1008u32, 1000, 4);
 		assert_eq!(1008, t);
 
-		let t = vote_target::<MockBlock>(block(1016), block(1000), 4);
+		let t = vote_target(1016u32, 1000, 4);
 		assert_eq!(1016, t);
 
-		let t = vote_target::<MockBlock>(block(1032), block(1000), 4);
+		let t = vote_target(1032u32, 1000, 4);
 		assert_eq!(1032, t);
 
-		let t = vote_target::<MockBlock>(block(1064), block(1000), 4);
+		let t = vote_target(1064u32, 1000, 4);
 		assert_eq!(1064, t);
 
-		let t = vote_target::<MockBlock>(block(1128), block(1000), 4);
+		let t = vote_target(1128u32, 1000, 4);
 		assert_eq!(1128, t);
 
-		let t = vote_target::<MockBlock>(block(1256), block(1000), 4);
+		let t = vote_target(1256u32, 1000, 4);
 		assert_eq!(1256, t);
 
-		let t = vote_target::<MockBlock>(block(1512), block(1000), 4);
+		let t = vote_target(1512u32, 1000, 4);
 		assert_eq!(1512, t);
 
-		let t = vote_target::<MockBlock>(block(1024), block(0), 4);
+		let t = vote_target(1024u32, 0, 4);
 		assert_eq!(1024, t);
 	}
 
 	#[test]
 	fn vote_on_target_block() {
-		let t = vote_target::<MockBlock>(block(1008), block(1002), 4);
+		let t = vote_target(1008u32, 1002, 4);
 		assert_eq!(1010, t);
-		let t = vote_target::<MockBlock>(block(1010), block(1002), 4);
+		let t = vote_target(1010u32, 1002, 4);
 		assert_eq!(1010, t);
 
-		let t = vote_target::<MockBlock>(block(1016), block(1006), 4);
+		let t = vote_target(1016u32, 1006, 4);
 		assert_eq!(1022, t);
-		let t = vote_target::<MockBlock>(block(1022), block(1006), 4);
+		let t = vote_target(1022u32, 1006, 4);
 		assert_eq!(1022, t);
 
-		let t = vote_target::<MockBlock>(block(1032), block(1012), 4);
+		let t = vote_target(1032u32, 1012, 4);
 		assert_eq!(1044, t);
-		let t = vote_target::<MockBlock>(block(1044), block(1012), 4);
+		let t = vote_target(1044u32, 1012, 4);
 		assert_eq!(1044, t);
 
-		let t = vote_target::<MockBlock>(block(1064), block(1014), 4);
+		let t = vote_target(1064u32, 1014, 4);
 		assert_eq!(1078, t);
-		let t = vote_target::<MockBlock>(block(1078), block(1014), 4);
+		let t = vote_target(1078u32, 1014, 4);
 		assert_eq!(1078, t);
 
-		let t = vote_target::<MockBlock>(block(1128), block(1008), 4);
+		let t = vote_target(1128u32, 1008, 4);
 		assert_eq!(1136, t);
-		let t = vote_target::<MockBlock>(block(1136), block(1008), 4);
+		let t = vote_target(1136u32, 1008, 4);
 		assert_eq!(1136, t);
 	}
 }


### PR DESCRIPTION
Use `best_beefy_block` to calculate next block to vote on instead of `best_block_voted_on`.

This fixes an issue if a chain gets restarted. Let the best GRANDPA finalized block after a restart be `1024`. Due to the restart, `best_block_voted_on` will be initialized to `0`. In this case `should_vote_on()` will calculate `next_block_to_vote_on` as `512`. In other words, we would never 'catch up' in terms of which block number to vote on, because `best_block_voted_on` stays at `0`