### PR TITLE
Make concluded round an info log

### DIFF
--- a/beefy-gadget/src/worker.rs
+++ b/beefy-gadget/src/worker.rs
@@ -24,7 +24,7 @@ use std::{
 use codec::{Codec, Decode, Encode};
 use futures::{future, FutureExt, StreamExt};
 use hex::ToHex;
-use log::{debug, error, trace, warn};
+use log::{debug, error, info, trace, warn};
 use parking_lot::Mutex;
 
 use sc_client_api::{Backend, FinalityNotification, FinalityNotifications};
@@ -332,7 +332,7 @@ where
 
 				metric_set!(self, beefy_round_concluded, round.1);
 
-				debug!(target: "beefy", "🥩 Round #{} concluded, committed: {:?}.", round.1, signed_commitment);
+				info!(target: "beefy", "🥩 Round #{} concluded, committed: {:?}.", round.1, signed_commitment);
 
 				if self
 					.backend


### PR DESCRIPTION
This allows to monitor for which block a signed commitment / justification has been produced. 