### PR TITLE
Remove external crypto trait bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,7 @@ dependencies = [
 name = "beefy-primitives"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "hex-literal",
  "parity-scale-codec",
  "sp-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,12 +580,12 @@ dependencies = [
 name = "beefy-primitives"
 version = "0.1.0"
 dependencies = [
- "hex",
  "hex-literal",
  "parity-scale-codec",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
+ "sp-keystore",
  "sp-runtime",
  "sp-std",
 ]

--- a/beefy-cli/src/cli/uncompress_authorities.rs
+++ b/beefy-cli/src/cli/uncompress_authorities.rs
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::cli::utils::{parse_hex, Authorities};
-use beefy_primitives::ecdsa::AuthorityId;
+use beefy_primitives::crypto::AuthorityId;
 use parity_scale_codec::Decode;
 use structopt::StructOpt;
 

--- a/beefy-cli/src/cli/utils.rs
+++ b/beefy-cli/src/cli/utils.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use beefy_primitives::ecdsa::AuthorityId;
+use beefy_primitives::crypto::AuthorityId;
 use parity_scale_codec::Decode;
 
 /// Parse hex string to a vector of bytes.

--- a/beefy-gadget/rpc/src/lib.rs
+++ b/beefy-gadget/rpc/src/lib.rs
@@ -63,14 +63,14 @@ pub trait BeefyApi<Notification, Hash> {
 }
 
 /// Implements the BeefyApi RPC trait for interacting with BEEFY.
-pub struct BeefyRpcHandler<Block: BlockT, Signature> {
-	signed_commitment_stream: BeefySignedCommitmentStream<Block, Signature>,
+pub struct BeefyRpcHandler<Block: BlockT> {
+	signed_commitment_stream: BeefySignedCommitmentStream<Block>,
 	manager: SubscriptionManager,
 }
 
-impl<Block: BlockT, Signature> BeefyRpcHandler<Block, Signature> {
+impl<Block: BlockT> BeefyRpcHandler<Block> {
 	/// Creates a new BeefyRpcHandler instance.
-	pub fn new<E>(signed_commitment_stream: BeefySignedCommitmentStream<Block, Signature>, executor: E) -> Self
+	pub fn new<E>(signed_commitment_stream: BeefySignedCommitmentStream<Block>, executor: E) -> Self
 	where
 		E: Executor01<Box<dyn Future01<Item = (), Error = ()> + Send>> + Send + Sync + 'static,
 	{
@@ -82,10 +82,9 @@ impl<Block: BlockT, Signature> BeefyRpcHandler<Block, Signature> {
 	}
 }
 
-impl<Block, Signature> BeefyApi<notification::SignedCommitment, Block> for BeefyRpcHandler<Block, Signature>
+impl<Block> BeefyApi<notification::SignedCommitment, Block> for BeefyRpcHandler<Block>
 where
 	Block: BlockT,
-	Signature: Clone + Encode + Send + 'static,
 {
 	type Metadata = sc_rpc::Metadata;
 
@@ -97,7 +96,7 @@ where
 		let stream = self
 			.signed_commitment_stream
 			.subscribe()
-			.map(|x| Ok::<_, ()>(notification::SignedCommitment::new::<Block, Signature>(x)))
+			.map(|x| Ok::<_, ()>(notification::SignedCommitment::new::<Block>(x)))
 			.map_err(|e| warn!("Notification stream error: {:?}", e))
 			.compat();
 

--- a/beefy-gadget/rpc/src/lib.rs
+++ b/beefy-gadget/rpc/src/lib.rs
@@ -19,7 +19,6 @@
 #![warn(missing_docs)]
 
 use beefy_gadget::notification::BeefySignedCommitmentStream;
-use codec::Encode;
 use futures::{StreamExt, TryStreamExt};
 use jsonrpc_core::futures::{
 	future::{Executor as Executor01, Future as Future01},

--- a/beefy-gadget/rpc/src/notification.rs
+++ b/beefy-gadget/rpc/src/notification.rs
@@ -26,12 +26,9 @@ use sp_runtime::traits::Block as BlockT;
 pub struct SignedCommitment(sp_core::Bytes);
 
 impl SignedCommitment {
-	pub fn new<Block, Signature>(
-		signed_commitment: beefy_gadget::notification::SignedCommitment<Block, Signature>,
-	) -> Self
+	pub fn new<Block>(signed_commitment: beefy_gadget::notification::SignedCommitment<Block>) -> Self
 	where
 		Block: BlockT,
-		Signature: Encode,
 	{
 		SignedCommitment(signed_commitment.encode().into())
 	}

--- a/beefy-gadget/src/error.rs
+++ b/beefy-gadget/src/error.rs
@@ -20,15 +20,10 @@
 
 use std::fmt::Debug;
 
-use sp_core::crypto::Public;
-
-/// Crypto related errors
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum Crypto<Id: Public + Debug> {
-	/// Check signature error
-	#[error("Message signature {0} by {1:?} is invalid.")]
-	InvalidSignature(String, Id),
-	/// Sign commitment error
-	#[error("Failed to sign comitment using key: {0:?}. Reason: {1}")]
-	CannotSign(Id, String),
+#[derive(Debug, thiserror::Error, PartialEq)]
+pub enum Error {
+	#[error("Keystore error: {0}")]
+	Keystore(String),
+	#[error("Signature error: {0}")]
+	Signature(String),
 }

--- a/beefy-gadget/src/keystore.rs
+++ b/beefy-gadget/src/keystore.rs
@@ -36,7 +36,7 @@ impl BeefyKeystore {
 	///
 	/// Return the public key for which we also do have a private key. If no
 	/// matching private key is found, `None` will be returned.
-	fn authority_id(&self, keys: &[Public]) -> Option<Public> {
+	pub fn authority_id(&self, keys: &[Public]) -> Option<Public> {
 		let store = if let Some(store) = self.0.clone() {
 			store
 		} else {
@@ -57,7 +57,7 @@ impl BeefyKeystore {
 	/// Note that `message` usually will be pre-hashed before being singed.
 	///
 	/// Return the message signature or an error in case of failure.
-	fn sign(&self, public: &Public, message: &[u8]) -> Result<Signature, error::Error> {
+	pub fn sign(&self, public: &Public, message: &[u8]) -> Result<Signature, error::Error> {
 		let store = if let Some(store) = self.0.clone() {
 			store
 		} else {
@@ -83,7 +83,7 @@ impl BeefyKeystore {
 	/// Use the `public` key to verify that `sig` is a valid signature for `message`.
 	///
 	/// Return `true` if the signature is authentic, `false` otherwise.
-	fn verify(public: &Public, sig: &Signature, message: &[u8]) -> bool {
+	pub fn verify(public: &Public, sig: &Signature, message: &[u8]) -> bool {
 		let msg = keccak_256(message);
 		let sig = sig.as_ref();
 		let public = public.as_ref();

--- a/beefy-gadget/src/keystore.rs
+++ b/beefy-gadget/src/keystore.rs
@@ -37,11 +37,7 @@ impl BeefyKeystore {
 	/// Return the public key for which we also do have a private key. If no
 	/// matching private key is found, `None` will be returned.
 	pub fn authority_id(&self, keys: &[Public]) -> Option<Public> {
-		let store = if let Some(store) = self.0.clone() {
-			store
-		} else {
-			return None;
-		};
+		let store = self.0.clone()?;
 
 		for key in keys {
 			if SyncCryptoStore::has_keys(&*store, &[(key.to_raw_vec(), KEY_TYPE)]) {

--- a/beefy-gadget/src/keystore.rs
+++ b/beefy-gadget/src/keystore.rs
@@ -1,0 +1,210 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::convert::TryInto;
+
+use sp_application_crypto::RuntimeAppPublic;
+use sp_core::keccak_256;
+use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
+
+use beefy_primitives::{
+	crypto::{Public, Signature},
+	KEY_TYPE,
+};
+
+use crate::error;
+
+/// A BEEFY specific keystore implemented as a `Newtype`. This is basically a
+/// wrapper around [`sp_keystore::SyncCryptoStore`] and allows to customize
+/// common cryptographic functionality.
+pub(crate) struct BeefyKeystore(Option<SyncCryptoStorePtr>);
+
+impl BeefyKeystore {
+	/// Check if the keystore contains a private key for one of the public keys
+	/// contained in `keys`. A public key with a matching private key is known
+	/// as a local authority id.
+	///
+	/// Return the public key for which we also do have a private key. If no
+	/// matching private key is found, `None` will be returned.
+	fn authority_id(&self, keys: &[Public]) -> Option<Public> {
+		let store = if let Some(store) = self.0.clone() {
+			store
+		} else {
+			return None;
+		};
+
+		for key in keys {
+			if SyncCryptoStore::has_keys(&*store, &[(key.to_raw_vec(), KEY_TYPE)]) {
+				return Some(key.clone());
+			}
+		}
+
+		None
+	}
+
+	/// Sign `message` with the `public` key.
+	///
+	/// Note that `message` usually will be pre-hashed before being singed.
+	///
+	/// Return the message signature or an error in case of failure.
+	fn sign(&self, public: &Public, message: &[u8]) -> Result<Signature, error::Error> {
+		let store = if let Some(store) = self.0.clone() {
+			store
+		} else {
+			return Err(error::Error::Keystore("no Keystore".to_string()));
+		};
+
+		let msg = keccak_256(message);
+		let public = public.as_ref();
+
+		let sig = SyncCryptoStore::ecdsa_sign_prehashed(&*store, KEY_TYPE, public, &msg)
+			.map_err(|e| error::Error::Keystore(e.to_string()))?
+			.ok_or_else(|| error::Error::Signature("ecdsa_sign_prehashed() failed".to_string()))?;
+
+		// check that `sig` has the expected result type
+		let sig = sig
+			.clone()
+			.try_into()
+			.map_err(|_| error::Error::Signature(format!("invalid signature {:?} for key {:?}", sig, public)))?;
+
+		Ok(sig)
+	}
+
+	/// Use the `public` key to verify that `sig` is a valid signature for `message`.
+	///
+	/// Return `true` if the signature is authentic, `false` otherwise.
+	fn verify(public: &Public, sig: &Signature, message: &[u8]) -> bool {
+		let msg = keccak_256(message);
+		let sig = sig.as_ref();
+		let public = public.as_ref();
+
+		sp_core::ecdsa::Pair::verify_prehashed(sig, &msg, public)
+	}
+}
+
+impl From<Option<SyncCryptoStorePtr>> for BeefyKeystore {
+	fn from(store: Option<SyncCryptoStorePtr>) -> BeefyKeystore {
+		BeefyKeystore(store)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#![allow(clippy::unit_cmp)]
+
+	use sp_core::{keccak_256, Pair};
+	use sp_keystore::{testing::KeyStore, SyncCryptoStore, SyncCryptoStorePtr};
+
+	use beefy_primitives::{crypto, KEY_TYPE};
+
+	use super::BeefyKeystore;
+	use crate::error::Error;
+
+	#[test]
+	fn authority_id_works() {
+		let store: SyncCryptoStorePtr = KeyStore::new().into();
+
+		let alice = crypto::Pair::from_string("//Alice", None).unwrap();
+		let _ = SyncCryptoStore::insert_unknown(&*store, KEY_TYPE, "//Alice", alice.public().as_ref()).unwrap();
+
+		let bob = crypto::Pair::from_string("//Bob", None).unwrap();
+		let charlie = crypto::Pair::from_string("//Charlie", None).unwrap();
+
+		let store: BeefyKeystore = Some(store).into();
+
+		let mut keys = vec![bob.public(), charlie.public()];
+
+		let id = store.authority_id(keys.as_slice());
+		assert!(id.is_none());
+
+		keys.push(alice.public());
+
+		let id = store.authority_id(keys.as_slice()).unwrap();
+		assert_eq!(id, alice.public());
+	}
+
+	#[test]
+	fn sign_works() {
+		let store: SyncCryptoStorePtr = KeyStore::new().into();
+
+		let suri = "//Alice";
+		let pair = sp_core::ecdsa::Pair::from_string(suri, None).unwrap();
+
+		let res = SyncCryptoStore::insert_unknown(&*store, KEY_TYPE, suri, pair.public().as_ref()).unwrap();
+		assert_eq!((), res);
+
+		let beefy_store: BeefyKeystore = Some(store.clone()).into();
+
+		let msg = b"are you involved or commited?";
+		let sig1 = beefy_store.sign(&pair.public().into(), msg).unwrap();
+
+		let msg = keccak_256(b"are you involved or commited?");
+		let sig2 = SyncCryptoStore::ecdsa_sign_prehashed(&*store, KEY_TYPE, &pair.public(), &msg)
+			.unwrap()
+			.unwrap();
+
+		assert_eq!(sig1, sig2.into());
+	}
+
+	#[test]
+	fn sign_error() {
+		let store: SyncCryptoStorePtr = KeyStore::new().into();
+
+		let bob = crypto::Pair::from_string("//Bob", None).unwrap();
+		let res = SyncCryptoStore::insert_unknown(&*store, KEY_TYPE, "//Bob", bob.public().as_ref()).unwrap();
+		assert_eq!((), res);
+
+		let alice = crypto::Pair::from_string("//Alice", None).unwrap();
+
+		let store: BeefyKeystore = Some(store).into();
+
+		let msg = b"are you involved or commited?";
+		let sig = store.sign(&alice.public(), msg).err().unwrap();
+		let err = Error::Signature("ecdsa_sign_prehashed() failed".to_string());
+		assert_eq!(sig, err);
+	}
+
+	#[test]
+	fn sign_no_keystore() {
+		let store: BeefyKeystore = None.into();
+
+		let alice = crypto::Pair::from_string("//Alice", None).unwrap();
+		let msg = b"are you involved or commited";
+
+		let sig = store.sign(&alice.public(), msg).err().unwrap();
+		let err = Error::Keystore("no Keystore".to_string());
+		assert_eq!(sig, err);
+	}
+
+	#[test]
+	fn verify_works() {
+		let store: SyncCryptoStorePtr = KeyStore::new().into();
+
+		let suri = "//Alice";
+		let pair = crypto::Pair::from_string(suri, None).unwrap();
+
+		let res = SyncCryptoStore::insert_unknown(&*store, KEY_TYPE, suri, pair.public().as_ref()).unwrap();
+		assert_eq!((), res);
+
+		let store: BeefyKeystore = Some(store).into();
+
+		// `msg` and `sig` match
+		let msg = b"are you involved or commited?";
+		let sig = store.sign(&pair.public(), msg).unwrap();
+		assert!(BeefyKeystore::verify(&pair.public(), &sig, msg));
+
+		// `msg and `sig` don't match
+		let msg = b"you are just involved";
+		assert!(!BeefyKeystore::verify(&pair.public(), &sig, msg));
+	}
+}

--- a/beefy-gadget/src/lib.rs
+++ b/beefy-gadget/src/lib.rs
@@ -14,25 +14,28 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{convert::TryFrom, fmt::Debug, sync::Arc};
+use std::sync::Arc;
 
-use codec::Codec;
 use log::debug;
 use prometheus::Registry;
+use codec::Codec;
 
 use sc_client_api::{Backend, BlockchainEvents, Finalizer};
 use sc_network_gossip::{GossipEngine, Network as GossipNetwork};
 
 use sp_api::ProvideRuntimeApi;
-use sp_application_crypto::AppPublic;
 use sp_blockchain::HeaderBackend;
 use sp_keystore::SyncCryptoStorePtr;
 use sp_runtime::traits::Block;
 
-use beefy_primitives::BeefyApi;
+use beefy_primitives::{
+	crypto::{Public, Signature},
+	BeefyApi,
+};
 
 mod error;
 mod gossip;
+mod keystore;
 mod metrics;
 mod round;
 mod worker;
@@ -53,36 +56,32 @@ pub fn beefy_peers_set_config() -> sc_network::config::NonDefaultSetConfig {
 /// has to satisfy. Ideally that should actually be a trait alias. Unfortunately as
 /// of today, Rust does not allow a type alias to be used as a trait bound. Tracking
 /// issue is <https://github.com/rust-lang/rust/issues/41517>.
-pub trait Client<B, BE, P>:
+pub trait Client<B, BE>:
 	BlockchainEvents<B> + HeaderBackend<B> + Finalizer<B, BE> + ProvideRuntimeApi<B> + Send + Sync
 where
 	B: Block,
 	BE: Backend<B>,
-	P: sp_core::Pair,
-	P::Public: AppPublic + Codec,
-	P::Signature: Clone + Codec + Debug + PartialEq + TryFrom<Vec<u8>>,
 {
 	// empty
 }
 
-impl<B, BE, P, T> Client<B, BE, P> for T
+impl<B, BE, T> Client<B, BE> for T
 where
 	B: Block,
 	BE: Backend<B>,
-	P: sp_core::Pair,
-	P::Public: AppPublic + Codec,
-	P::Signature: Clone + Codec + Debug + PartialEq + TryFrom<Vec<u8>>,
 	T: BlockchainEvents<B> + HeaderBackend<B> + Finalizer<B, BE> + ProvideRuntimeApi<B> + Send + Sync,
 {
 	// empty
 }
 
 /// BEEFY gadget initialization parameters.
-pub struct BeefyParams<B, P, BE, C, N>
+pub struct BeefyParams<B, BE, C, N>
 where
 	B: Block,
-	P: sp_core::Pair,
-	P::Signature: Clone + Codec + Debug + PartialEq + TryFrom<Vec<u8>>,
+	BE: Backend<B>,
+	C: Client<B, BE>,
+	//C::Api: BeefyApi<B, dyn Codec>,
+	N: GossipNetwork<B> + Clone + Send + 'static,
 {
 	/// BEEFY client
 	pub client: Arc<C>,
@@ -93,7 +92,7 @@ where
 	/// Gossip network
 	pub network: N,
 	/// BEEFY signed commitment sender
-	pub signed_commitment_sender: notification::BeefySignedCommitmentSender<B, P::Signature>,
+	pub signed_commitment_sender: notification::BeefySignedCommitmentSender<B>,
 	/// Minimal delta between blocks, BEEFY should vote for
 	pub min_block_delta: u32,
 	/// Prometheus metric registry
@@ -103,15 +102,12 @@ where
 /// Start the BEEFY gadget.
 ///
 /// This is a thin shim around running and awaiting a BEEFY worker.
-pub async fn start_beefy_gadget<B, P, BE, C, N>(beefy_params: BeefyParams<B, P, BE, C, N>)
+pub async fn start_beefy_gadget<B, BE, C, N>(beefy_params: BeefyParams<B, BE, C, N>)
 where
 	B: Block,
-	P: sp_core::Pair,
-	P::Public: AppPublic + Codec,
-	P::Signature: Clone + Codec + Debug + PartialEq + TryFrom<Vec<u8>>,
 	BE: Backend<B>,
-	C: Client<B, BE, P>,
-	C::Api: BeefyApi<B, P::Public>,
+	C: Client<B, BE>,
+	//C::Api: BeefyApi<B, Codec>,
 	N: GossipNetwork<B> + Clone + Send + 'static,
 {
 	let BeefyParams {
@@ -144,7 +140,7 @@ where
 	let worker_params = worker::WorkerParams {
 		client,
 		backend,
-		key_store,
+		key_store: key_store.into(),
 		signed_commitment_sender,
 		gossip_engine,
 		gossip_validator,
@@ -152,7 +148,7 @@ where
 		metrics,
 	};
 
-	let worker = worker::BeefyWorker::<_, _, _, _>::new(worker_params);
+	let worker = worker::BeefyWorker::<_, _, _,_>::new(worker_params);
 
 	worker.run().await
 }

--- a/beefy-gadget/src/lib.rs
+++ b/beefy-gadget/src/lib.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use log::debug;
 use prometheus::Registry;
-use codec::Codec;
 
 use sc_client_api::{Backend, BlockchainEvents, Finalizer};
 use sc_network_gossip::{GossipEngine, Network as GossipNetwork};
@@ -28,10 +27,7 @@ use sp_blockchain::HeaderBackend;
 use sp_keystore::SyncCryptoStorePtr;
 use sp_runtime::traits::Block;
 
-use beefy_primitives::{
-	crypto::{Public, Signature},
-	BeefyApi,
-};
+use beefy_primitives::BeefyApi;
 
 mod error;
 mod gossip;
@@ -80,7 +76,7 @@ where
 	B: Block,
 	BE: Backend<B>,
 	C: Client<B, BE>,
-	//C::Api: BeefyApi<B, dyn Codec>,
+	C::Api: BeefyApi<B>,
 	N: GossipNetwork<B> + Clone + Send + 'static,
 {
 	/// BEEFY client
@@ -107,7 +103,7 @@ where
 	B: Block,
 	BE: Backend<B>,
 	C: Client<B, BE>,
-	//C::Api: BeefyApi<B, Codec>,
+	C::Api: BeefyApi<B>,
 	N: GossipNetwork<B> + Clone + Send + 'static,
 {
 	let BeefyParams {
@@ -148,7 +144,7 @@ where
 		metrics,
 	};
 
-	let worker = worker::BeefyWorker::<_, _, _,_>::new(worker_params);
+	let worker = worker::BeefyWorker::<_, _, _>::new(worker_params);
 
 	worker.run().await
 }

--- a/beefy-gadget/src/worker.rs
+++ b/beefy-gadget/src/worker.rs
@@ -14,16 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{
-	convert::{TryFrom, TryInto},
-	fmt::Debug,
-	marker::PhantomData,
-	sync::Arc,
-};
+use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
 use codec::{Codec, Decode, Encode};
 use futures::{future, FutureExt, StreamExt};
-use hex::ToHex;
 use log::{debug, error, info, trace, warn};
 use parking_lot::Mutex;
 
@@ -31,10 +25,7 @@ use sc_client_api::{Backend, FinalityNotification, FinalityNotifications};
 use sc_network_gossip::GossipEngine;
 
 use sp_api::BlockId;
-use sp_application_crypto::{AppPublic, Public};
 use sp_arithmetic::traits::AtLeast32Bit;
-use sp_core::Pair;
-use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 use sp_runtime::{
 	generic::OpaqueDigestItemId,
 	traits::{Block, Header, NumberFor},
@@ -42,54 +33,51 @@ use sp_runtime::{
 };
 
 use beefy_primitives::{
+	crypto::{Public, Signature},
 	BeefyApi, Commitment, ConsensusLog, MmrRootHash, SignedCommitment, ValidatorSet, VersionedCommitment, VoteMessage,
-	BEEFY_ENGINE_ID, GENESIS_AUTHORITY_SET_ID, KEY_TYPE,
+	BEEFY_ENGINE_ID, GENESIS_AUTHORITY_SET_ID,
 };
 
 use crate::{
 	error::{self},
 	gossip::{topic, BeefyGossipValidator},
+	keystore::BeefyKeystore,
 	metric_inc, metric_set,
 	metrics::Metrics,
 	notification, round, Client,
 };
 
-pub(crate) struct WorkerParams<B, P, BE, C>
+pub(crate) struct WorkerParams<B, BE, C>
 where
 	B: Block,
-	P: sp_core::Pair,
-	P::Signature: Clone + Codec + Debug + PartialEq + TryFrom<Vec<u8>>,
 {
 	pub client: Arc<C>,
 	pub backend: Arc<BE>,
-	pub key_store: Option<SyncCryptoStorePtr>,
-	pub signed_commitment_sender: notification::BeefySignedCommitmentSender<B, P::Signature>,
+	pub key_store: BeefyKeystore,
+	pub signed_commitment_sender: notification::BeefySignedCommitmentSender<B>,
 	pub gossip_engine: GossipEngine<B>,
-	pub gossip_validator: Arc<BeefyGossipValidator<B, P>>,
+	pub gossip_validator: Arc<BeefyGossipValidator<B>>,
 	pub min_block_delta: u32,
 	pub metrics: Option<Metrics>,
 }
 
 /// A BEEFY worker plays the BEEFY protocol
-pub(crate) struct BeefyWorker<B, C, BE, P>
+pub(crate) struct BeefyWorker<B, C, BE>
 where
 	B: Block,
 	BE: Backend<B>,
-	P: Pair,
-	P::Public: AppPublic + Codec,
-	P::Signature: Clone + Codec + Debug + PartialEq + TryFrom<Vec<u8>>,
-	C: Client<B, BE, P>,
+	C: Client<B, BE>,
 {
 	client: Arc<C>,
 	backend: Arc<BE>,
-	key_store: Option<SyncCryptoStorePtr>,
-	signed_commitment_sender: notification::BeefySignedCommitmentSender<B, P::Signature>,
+	key_store: BeefyKeystore,
+	signed_commitment_sender: notification::BeefySignedCommitmentSender<B>,
 	gossip_engine: Arc<Mutex<GossipEngine<B>>>,
-	gossip_validator: Arc<BeefyGossipValidator<B, P>>,
+	gossip_validator: Arc<BeefyGossipValidator<B>>,
 	/// Min delta in block numbers between two blocks, BEEFY should vote on
 	min_block_delta: u32,
 	metrics: Option<Metrics>,
-	rounds: round::Rounds<MmrRootHash, NumberFor<B>, P::Public, P::Signature>,
+	rounds: round::Rounds<MmrRootHash, NumberFor<B>>,
 	finality_notifications: FinalityNotifications<B>,
 	/// Best block we received a GRANDPA notification for
 	best_grandpa_block: NumberFor<B>,
@@ -99,18 +87,14 @@ where
 	last_signed_id: u64,
 	// keep rustc happy
 	_backend: PhantomData<BE>,
-	_pair: PhantomData<P>,
 }
 
-impl<B, C, BE, P> BeefyWorker<B, C, BE, P>
+impl<B, C, BE> BeefyWorker<B, C, BE>
 where
-	B: Block,
+	B: Block + Codec,
 	BE: Backend<B>,
-	P: Pair,
-	P::Public: AppPublic,
-	P::Signature: Clone + Codec + Debug + PartialEq + TryFrom<Vec<u8>>,
-	C: Client<B, BE, P>,
-	C::Api: BeefyApi<B, P::Public>,
+	C: Client<B, BE>,
+	C::Api: BeefyApi<B>,
 {
 	/// Return a new BEEFY worker instance.
 	///
@@ -118,7 +102,7 @@ where
 	/// BEEFY pallet has been deployed on-chain.
 	///
 	/// The BEEFY pallet is needed in order to keep track of the BEEFY authority set.
-	pub(crate) fn new(worker_params: WorkerParams<B, P, BE, C>) -> Self {
+	pub(crate) fn new(worker_params: WorkerParams<B, BE, C>) -> Self {
 		let WorkerParams {
 			client,
 			backend,
@@ -145,20 +129,16 @@ where
 			best_beefy_block: None,
 			last_signed_id: 0,
 			_backend: PhantomData,
-			_pair: PhantomData,
 		}
 	}
 }
 
-impl<B, C, BE, P> BeefyWorker<B, C, BE, P>
+impl<B, C, BE> BeefyWorker<B, C, BE>
 where
 	B: Block,
 	BE: Backend<B>,
-	P: Pair,
-	P::Public: AppPublic,
-	P::Signature: Clone + Codec + Debug + PartialEq + TryFrom<Vec<u8>>,
-	C: Client<B, BE, P>,
-	C::Api: BeefyApi<B, P::Public>,
+	C: Client<B, BE>,
+	C::Api: BeefyApi<B>,
 {
 	/// Return `true`, if we should vote on block `number`
 	fn should_vote_on(&self, number: NumberFor<B>) -> bool {
@@ -178,22 +158,8 @@ where
 		number == target
 	}
 
-	fn sign_commitment(&self, id: &P::Public, commitment: &[u8]) -> Result<P::Signature, error::Crypto<P::Public>> {
-		let key_store = self
-			.key_store
-			.clone()
-			.ok_or_else(|| error::Crypto::CannotSign((*id).clone(), "Missing KeyStore".into()))?;
-
-		let sig = SyncCryptoStore::sign_with(&*key_store, KEY_TYPE, &id.to_public_crypto_pair(), commitment)
-			.map_err(|e| error::Crypto::CannotSign((*id).clone(), e.to_string()))?
-			.ok_or_else(|| error::Crypto::CannotSign((*id).clone(), "No key in KeyStore found".into()))?;
-
-		let sig = sig
-			.clone()
-			.try_into()
-			.map_err(|_| error::Crypto::InvalidSignature(sig.encode_hex(), (*id).clone()))?;
-
-		Ok(sig)
+	fn sign_commitment(&self, id: &Public, commitment: &[u8]) -> Result<Signature, error::Error> {
+		self.key_store.sign(id, commitment)
 	}
 
 	/// Return the current active validator set at header `header`.
@@ -203,8 +169,8 @@ where
 	/// BEEFY on-chain state.
 	///
 	/// Such a failure is usually an indication that the BEEFT pallet has not been deployed (yet).
-	fn validator_set(&self, header: &B::Header) -> Option<ValidatorSet<P::Public>> {
-		if let Some(new) = find_authorities_change::<B, P::Public>(header) {
+	fn validator_set(&self, header: &B::Header) -> Option<ValidatorSet<Public>> {
+		if let Some(new) = find_authorities_change::<B, Public>(header) {
 			Some(new)
 		} else {
 			let at = BlockId::hash(header.hash());
@@ -215,14 +181,8 @@ where
 	/// Return the local authority id.
 	///
 	/// `None` is returned, if we are not permitted to vote
-	fn local_id(&self) -> Option<P::Public> {
-		let key_store = self.key_store.clone()?;
-
-		self.rounds
-			.validators()
-			.iter()
-			.find(|id| SyncCryptoStore::has_keys(&*key_store, &[(id.to_raw_vec(), KEY_TYPE)]))
-			.cloned()
+	fn local_id(&self) -> Option<Public> {
+		self.key_store.authority_id(&self.rounds.validators().as_slice())
 	}
 
 	fn handle_finality_notification(&mut self, notification: FinalityNotification<B>) {
@@ -268,7 +228,7 @@ where
 				return;
 			};
 
-			let mmr_root = if let Some(hash) = find_mmr_root_digest::<B, P::Public>(&notification.header) {
+			let mmr_root = if let Some(hash) = find_mmr_root_digest::<B, Public>(&notification.header) {
 				hash
 			} else {
 				warn!(target: "beefy", "🥩 No MMR root digest found for: {:?}", notification.header.hash());
@@ -312,7 +272,7 @@ where
 		}
 	}
 
-	fn handle_vote(&mut self, round: (MmrRootHash, NumberFor<B>), vote: (P::Public, P::Signature)) {
+	fn handle_vote(&mut self, round: (MmrRootHash, NumberFor<B>), vote: (Public, Signature)) {
 		self.gossip_validator.note_round(round.1);
 
 		let vote_added = self.rounds.add_vote(round, vote);
@@ -363,10 +323,7 @@ where
 			|notification| async move {
 				trace!(target: "beefy", "🥩 Got vote message: {:?}", notification);
 
-				VoteMessage::<MmrRootHash, NumberFor<B>, P::Public, P::Signature>::decode(
-					&mut &notification.message[..],
-				)
-				.ok()
+				VoteMessage::<MmrRootHash, NumberFor<B>, Public, Signature>::decode(&mut &notification.message[..]).ok()
 			},
 		));
 

--- a/beefy-gadget/src/worker.rs
+++ b/beefy-gadget/src/worker.rs
@@ -182,7 +182,7 @@ where
 	///
 	/// `None` is returned, if we are not permitted to vote
 	fn local_id(&self) -> Option<Public> {
-		self.key_store.authority_id(&self.rounds.validators().as_slice())
+		self.key_store.authority_id(self.rounds.validators().as_slice())
 	}
 
 	fn handle_finality_notification(&mut self, notification: FinalityNotification<B>) {

--- a/beefy-node/node/src/chain_spec.rs
+++ b/beefy-node/node/src/chain_spec.rs
@@ -2,7 +2,7 @@ use beefy_node_runtime::{
 	AccountId, AuraConfig, BalancesConfig, BeefyConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig,
 	SystemConfig, WASM_BINARY,
 };
-use beefy_primitives::ecdsa::AuthorityId as BeefyId;
+use beefy_primitives::crypto::AuthorityId as BeefyId;
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{sr25519, Pair, Public};

--- a/beefy-node/node/src/rpc.rs
+++ b/beefy-node/node/src/rpc.rs
@@ -17,12 +17,11 @@ use sp_runtime::traits::Block as BlockT;
 use sp_transaction_pool::TransactionPool;
 
 use beefy_gadget::notification::BeefySignedCommitmentStream;
-use beefy_primitives::ecdsa::AuthoritySignature as BeefySignature;
 
 /// Extra dependencies for BEEFY
 pub struct BeefyDeps<B: BlockT> {
 	/// Receives notifications about signed commitments from BEEFY.
-	pub signed_commitment_stream: BeefySignedCommitmentStream<B, BeefySignature>,
+	pub signed_commitment_stream: BeefySignedCommitmentStream<B>,
 	/// Executor to drive the subscription manager in the BEEFY RPC handler.
 	pub subscription_executor: SubscriptionTaskExecutor,
 }

--- a/beefy-node/node/src/service.rs
+++ b/beefy-node/node/src/service.rs
@@ -262,7 +262,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 	// Start the BEEFY bridge gadget.
 	task_manager.spawn_essential_handle().spawn_blocking(
 		"beefy-gadget",
-		beefy_gadget::start_beefy_gadget::<_, beefy_primitives::ecdsa::AuthorityPair, _, _, _>(beefy_params),
+		beefy_gadget::start_beefy_gadget::<_, _, _, _>(beefy_params),
 	);
 
 	let grandpa_config = sc_finality_grandpa::Config {

--- a/beefy-node/runtime/src/lib.rs
+++ b/beefy-node/runtime/src/lib.rs
@@ -12,7 +12,7 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-use beefy_primitives::{ecdsa::AuthorityId as BeefyId, ValidatorSet};
+use beefy_primitives::{crypto::AuthorityId as BeefyId, ValidatorSet};
 use frame_system::limits;
 use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use sp_api::impl_runtime_apis;
@@ -455,7 +455,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl beefy_primitives::BeefyApi<Block, BeefyId> for Runtime {
+	impl beefy_primitives::BeefyApi<Block> for Runtime {
 		fn validator_set() -> ValidatorSet<BeefyId> {
 			Beefy::validator_set()
 		}

--- a/beefy-pallet/src/mock.rs
+++ b/beefy-pallet/src/mock.rs
@@ -31,7 +31,7 @@ use sp_runtime::{
 
 use crate as pallet_beefy;
 
-pub use beefy_primitives::{ecdsa::AuthorityId as BeefyId, ConsensusLog, BEEFY_ENGINE_ID};
+pub use beefy_primitives::{crypto::AuthorityId as BeefyId, ConsensusLog, BEEFY_ENGINE_ID};
 
 impl_opaque_keys! {
 	pub struct MockSessionKeys {

--- a/beefy-primitives/Cargo.toml
+++ b/beefy-primitives/Cargo.toml
@@ -16,7 +16,8 @@ sp-std = { git = "https://github.com/paritytech/substrate", default-features = f
 
 [dev-dependencies]
 hex-literal = "0.3"
-hex = "0.4"
+
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
 default = ["std"]

--- a/beefy-primitives/Cargo.toml
+++ b/beefy-primitives/Cargo.toml
@@ -16,6 +16,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", default-features = f
 
 [dev-dependencies]
 hex-literal = "0.3"
+hex = "0.4"
 
 [features]
 default = ["std"]

--- a/beefy-primitives/src/lib.rs
+++ b/beefy-primitives/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Parity Technologies (UK) Ltd.
+// Copyright (C) 2020-2021 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 // This program is free software: you can redistribute it and/or modify
@@ -56,11 +56,25 @@ pub mod ecdsa {
 		pub type AuthorityPair = app_ecdsa::Pair;
 	}
 
+	pub use app_ecdsa::*;
+
 	/// Identity of a BEEFY authority using ECDSA as its crypto.
 	pub type AuthorityId = app_ecdsa::Public;
 
 	/// Signature for a BEEFY authority using ECDSA as its crypto.
 	pub type AuthoritySignature = app_ecdsa::Signature;
+}
+
+/// BEEFY cryptographic types based on ECDSA
+pub mod crypto {
+	use sp_application_crypto::{app_crypto, ecdsa};
+	app_crypto!(ecdsa, crate::KEY_TYPE);
+
+	/// Identity of a BEEFY authority using ECDSA as its crypto.
+	pub type AuthorityId = Public;
+
+	/// Signature for a BEEFY authority using ECDSA as its crypto.
+	pub type AuthoritySignature = Signature;
 }
 
 /// The `ConsensusEngineId` of BEEFY.
@@ -127,7 +141,8 @@ pub struct VoteMessage<Hash, Number, Id, Signature> {
 
 sp_api::decl_runtime_apis! {
 	/// API necessary for BEEFY voters.
-	pub trait BeefyApi<AuthorityId: Codec> {
+	pub trait BeefyApi<AuthorityId: Codec>
+	{
 		/// Return the current active BEEFY validator set
 		fn validator_set() -> ValidatorSet<AuthorityId>;
 	}

--- a/beefy-primitives/src/lib.rs
+++ b/beefy-primitives/src/lib.rs
@@ -44,7 +44,18 @@ use sp_std::prelude::*;
 /// Key type for BEEFY module.
 pub const KEY_TYPE: sp_application_crypto::KeyTypeId = sp_application_crypto::KeyTypeId(*b"beef");
 
-/// BEEFY cryptographic types based on ECDSA
+/// BEEFY cryptographic types
+///
+/// This module basically introduces three crypto types:
+/// - `crypto::Pair`
+/// - `crypto::Public`
+/// - `crypto::Signature`
+///
+/// Your code should use the above types as concrete types for all crypto related
+/// functionality.
+///
+/// The current underlying crypto scheme used is ECDSA. This can be changed,
+/// without affecting code restricted against the above listed crypto types.
 pub mod crypto {
 	use sp_application_crypto::{app_crypto, ecdsa};
 	app_crypto!(ecdsa, crate::KEY_TYPE);

--- a/beefy-primitives/src/lib.rs
+++ b/beefy-primitives/src/lib.rs
@@ -44,27 +44,6 @@ use sp_std::prelude::*;
 /// Key type for BEEFY module.
 pub const KEY_TYPE: sp_application_crypto::KeyTypeId = sp_application_crypto::KeyTypeId(*b"beef");
 
-/// BEEFY application-specific crypto types using ECDSA.
-pub mod ecdsa {
-	mod app_ecdsa {
-		use sp_application_crypto::{app_crypto, ecdsa};
-		app_crypto!(ecdsa, crate::KEY_TYPE);
-	}
-
-	sp_application_crypto::with_pair! {
-		/// A BEEFY authority keypair using ECDSA as its crypto.
-		pub type AuthorityPair = app_ecdsa::Pair;
-	}
-
-	pub use app_ecdsa::*;
-
-	/// Identity of a BEEFY authority using ECDSA as its crypto.
-	pub type AuthorityId = app_ecdsa::Public;
-
-	/// Signature for a BEEFY authority using ECDSA as its crypto.
-	pub type AuthoritySignature = app_ecdsa::Signature;
-}
-
 /// BEEFY cryptographic types based on ECDSA
 pub mod crypto {
 	use sp_application_crypto::{app_crypto, ecdsa};
@@ -141,9 +120,9 @@ pub struct VoteMessage<Hash, Number, Id, Signature> {
 
 sp_api::decl_runtime_apis! {
 	/// API necessary for BEEFY voters.
-	pub trait BeefyApi<AuthorityId: Codec>
+	pub trait BeefyApi
 	{
 		/// Return the current active BEEFY validator set
-		fn validator_set() -> ValidatorSet<AuthorityId>;
+		fn validator_set() -> ValidatorSet<crypto::AuthorityId>;
 	}
 }

--- a/beefy-primitives/src/witness.rs
+++ b/beefy-primitives/src/witness.rs
@@ -24,8 +24,10 @@
 
 use sp_std::prelude::*;
 
-use crate::commitment::{Commitment, SignedCommitment};
-use crate::crypto::Signature;
+use crate::{
+	commitment::{Commitment, SignedCommitment},
+	crypto::Signature,
+};
 
 /// A light form of [SignedCommitment].
 ///
@@ -81,14 +83,38 @@ impl<TBlockNumber, TPayload, TMerkleRoot> SignedCommitmentWitness<TBlockNumber, 
 
 #[cfg(test)]
 mod tests {
-	use std::convert::TryInto;
+
+	use sp_core::{keccak_256, Pair};
+	use sp_keystore::{testing::KeyStore, SyncCryptoStore, SyncCryptoStorePtr};
 
 	use super::*;
 	use codec::Decode;
 
+	use crate::{crypto, KEY_TYPE};
+
 	type TestCommitment = Commitment<u128, String>;
 	type TestSignedCommitment = SignedCommitment<u128, String>;
 	type TestSignedCommitmentWitness = SignedCommitmentWitness<u128, String, Vec<Option<Signature>>>;
+
+	// The mock signatures are equivalent to the ones produced by the BEEFY keystore
+	fn mock_signatures() -> (crypto::Signature, crypto::Signature) {
+		let store: SyncCryptoStorePtr = KeyStore::new().into();
+
+		let alice = sp_core::ecdsa::Pair::from_string("//Alice", None).unwrap();
+		let _ = SyncCryptoStore::insert_unknown(&*store, KEY_TYPE, "//Alice", alice.public().as_ref()).unwrap();
+
+		let msg = keccak_256(b"This is the first message");
+		let sig1 = SyncCryptoStore::ecdsa_sign_prehashed(&*store, KEY_TYPE, &alice.public(), &msg)
+			.unwrap()
+			.unwrap();
+
+		let msg = keccak_256(b"This is the second message");
+		let sig2 = SyncCryptoStore::ecdsa_sign_prehashed(&*store, KEY_TYPE, &alice.public(), &msg)
+			.unwrap()
+			.unwrap();
+
+		(sig1.into(), sig2.into())
+	}
 
 	fn signed_commitment() -> TestSignedCommitment {
 		let commitment: TestCommitment = Commitment {
@@ -97,14 +123,11 @@ mod tests {
 			validator_set_id: 0,
 		};
 
+		let sigs = mock_signatures();
+
 		SignedCommitment {
 			commitment,
-			signatures: vec![
-				None,
-				None,
-				Some(vec![1, 2, 3, 4].try_into().unwrap()),
-				Some(vec![5, 6, 7, 8].try_into().unwrap()),
-			],
+			signatures: vec![None, None, Some(sigs.0), Some(sigs.1)],
 		}
 	}
 
@@ -134,9 +157,7 @@ mod tests {
 		assert_eq!(decoded, Ok(witness));
 		assert_eq!(
 			encoded,
-			hex_literal::hex!(
-				"3048656c6c6f20576f726c64210500000000000000000000000000000000000000000000001000000101100000011001020304011005060708"
-			)
+			hex_literal::hex!("3048656c6c6f20576f726c6421050000000000000000000000000000000000000000000000100000010110000001558455ad81279df0795cc985580e4fb75d72d948d1107b2ac80a09abed4da8480c746cc321f2319a5e99a830e314d10dd3cd68ce3dc0c33c86e99bcb7816f9ba01012d6e1f8105c337a86cdd9aaacdc496577f3db8c55ef9e6fd48f2c5c05a2274707491635d8ba3df64f324575b7b2a34487bca2324b6a0046395a71681be3d0c2a00")
 		);
 	}
 }

--- a/beefy-primitives/tests/basic_lc_operations.rs
+++ b/beefy-primitives/tests/basic_lc_operations.rs
@@ -361,5 +361,4 @@ fn light_client_reject_set_transition_with_invalid_proof() {
 	// then
 	assert_eq!(result, Err(Error::InvalidValidatorSetProof));
 }
-
 */

--- a/beefy-primitives/tests/basic_lc_operations.rs
+++ b/beefy-primitives/tests/basic_lc_operations.rs
@@ -14,9 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+/*
 mod light_client;
 
-use self::light_client::{validator_set, Commitment, Error, Payload, SignedCommitment};
+use std::convert::TryInto;
+
+use self::light_client::{Commitment, Error, Payload, SignedCommitment};
+
+use beefy_primitives::crypto::{Public, Signature};
 
 #[test]
 fn light_client_should_make_progress() {
@@ -30,7 +35,7 @@ fn light_client_should_make_progress() {
 			block_number: 2,
 			validator_set_id: 0,
 		},
-		signatures: vec![Some(validator_set::Signature::ValidFor(0.into()))],
+		signatures: vec![Some(vec![0].try_into().unwrap())],
 	});
 
 	// then
@@ -48,7 +53,7 @@ fn should_verify_mmr_proof() {
 			block_number: 2,
 			validator_set_id: 0,
 		},
-		signatures: vec![Some(validator_set::Signature::ValidFor(0.into()))],
+		signatures: vec![Some(vec![0].try_into().unwrap())],
 	})
 	.unwrap();
 
@@ -69,7 +74,7 @@ fn should_reject_invalid_mmr_proof() {
 			block_number: 2,
 			validator_set_id: 0,
 		},
-		signatures: vec![Some(validator_set::Signature::ValidFor(0.into()))],
+		signatures: vec![Some(vec![0].try_into().unwrap())],
 	})
 	.unwrap();
 
@@ -92,7 +97,7 @@ fn light_client_should_reject_invalid_validator_set() {
 			block_number: 1,
 			validator_set_id: 1,
 		},
-		signatures: vec![Some(validator_set::Signature::ValidFor(0.into()))],
+		signatures: vec![Some(vec![0].try_into().unwrap())],
 	});
 
 	// then
@@ -112,7 +117,7 @@ fn light_client_should_reject_set_transitions_without_validator_proof() {
 			block_number: 1,
 			validator_set_id: 1,
 		},
-		signatures: vec![Some(validator_set::Signature::ValidFor(0.into()))],
+		signatures: vec![Some(vec![0].try_into().unwrap())],
 	});
 
 	// then
@@ -131,7 +136,7 @@ fn light_client_should_reject_older_block() {
 			block_number: 10,
 			validator_set_id: 0,
 		},
-		signatures: vec![Some(validator_set::Signature::ValidFor(0.into()))],
+		signatures: vec![Some(vec![0].try_into().unwrap())],
 	})
 	.unwrap();
 
@@ -142,7 +147,7 @@ fn light_client_should_reject_older_block() {
 			block_number: 5,
 			validator_set_id: 0,
 		},
-		signatures: vec![Some(validator_set::Signature::ValidFor(0.into()))],
+		signatures: vec![Some(vec![0].try_into().unwrap())],
 	});
 
 	// then
@@ -215,7 +220,7 @@ fn light_client_should_reject_if_not_enough_valid_signatures() {
 			block_number: 5,
 			validator_set_id: 0,
 		},
-		signatures: vec![Some(validator_set::Signature::ValidFor(1.into()))],
+		signatures: vec![Some(vec![0].try_into().unwrap())],
 	});
 
 	// then
@@ -356,3 +361,5 @@ fn light_client_reject_set_transition_with_invalid_proof() {
 	// then
 	assert_eq!(result, Err(Error::InvalidValidatorSetProof));
 }
+
+*/

--- a/beefy-primitives/tests/light_client/mod.rs
+++ b/beefy-primitives/tests/light_client/mod.rs
@@ -14,10 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+/*
 use beefy_primitives::{self as bp, ValidatorSetId};
+use beefy_primitives::crypto::{Public, Signature};
 
 pub mod merkle_tree;
-pub mod validator_set;
 
 /// A marker struct for validator set merkle tree.
 #[derive(Debug)]
@@ -44,7 +45,7 @@ impl Payload {
 
 pub type BlockNumber = u64;
 pub type Commitment = bp::Commitment<BlockNumber, Payload>;
-pub type SignedCommitment = bp::SignedCommitment<BlockNumber, Payload, validator_set::Signature>;
+pub type SignedCommitment = bp::SignedCommitment<BlockNumber, Payload>;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
@@ -87,7 +88,7 @@ pub enum Error {
 	InvalidMmrProof,
 }
 
-type ValidatorSet = (ValidatorSetId, Vec<validator_set::Public>);
+type ValidatorSet = (ValidatorSetId, Vec<Public>);
 
 pub struct LightClient {
 	validator_set: ValidatorSet,
@@ -117,7 +118,7 @@ impl LightClient {
 	pub fn import_set_transition(
 		&mut self,
 		signed: SignedCommitment,
-		validator_set_proof: merkle_tree::Proof<ValidatorSetTree, Vec<validator_set::Public>>,
+		validator_set_proof: merkle_tree::Proof<ValidatorSetTree, Vec<Public>>,
 	) -> Result<(), Error> {
 		// Make sure it is a set transition block (see [import]).
 		if signed.commitment.validator_set_id != self.validator_set.0 + 1 {
@@ -242,8 +243,9 @@ impl LightClient {
 
 pub fn new() -> LightClient {
 	LightClient {
-		validator_set: (0, vec![validator_set::Public(0)]),
+		validator_set: (0, vec![Public(0)]),
 		next_validator_set: None,
 		last_commitment: None,
 	}
 }
+*/

--- a/beefy-primitives/tests/light_client/validator_set.rs
+++ b/beefy-primitives/tests/light_client/validator_set.rs
@@ -29,7 +29,7 @@ pub enum Signature {
 	Invalid,
 }
 
-impl Signature {
+impl beefy_primitives::crypto::Signature {
 	pub fn is_valid_for(&self, public: &Public) -> bool {
 		matches!(self, Self::ValidFor(ref p) if p == public)
 	}


### PR DESCRIPTION
Alternative implementation for #192.

- Refactor BEEFY crypto by getting rid of crypto related trait bounds.
- Implement `BeefyKeystore` as a newtype

Resolves: #82 

I have deactivated the light client tests for now.

Reading @tomusdrw review comments, I should have provided more context about the reasoning behind this PR right away. Let me do this now. I also changed the PR title to make the intention more clear.

First off, we all agree and it is well understood that the crypto BEEFY uses **internally** should be configurable. This PR is basically a first step in a two step process, refactoring BEEFY crypto in order to provide that configuration option. As such, the PR may seem a step backwards, which it actually is, kind of. 

Starting point were the struggles and the kind of code that had to be written for PR #192. Main root cause for the problems is the fact that BEEFY internal crypto is sort of exposed to the outside by introducing a crypto related trait bound on it's public interface (`sp_crypto::Pair`). IMO, what crypto BEEFY is using should be a purely BEEFY internal property. So, main goal of this PR is to remove the crypto related trait bound on BEEFY's public interface. The idea is, that after this PR is merged, BEEFY is functionally equivalent as to before the PR, by using ECDSA crypto.

But how can we configure BEEFY crypto now? BEEFY crypto is configured through the arguments used for the `app_crypto!()` macro. That is basically configuration through code generation. BEEFY code itself is typed against `beefy_primitives::crypto::{Pair, Public, Signature}`. Those types are newtype wrappers around concrete crypto types generated by the `app_crypto!()` macro.

Why is `BeefyKeystore` not generic? Due to the fact that BEEFY crypto is now configurable through code generation, there are multiple options, how to expose that configuration option. IMO, at this point in time, it is not clear which one is the most suitable. I think that the different options warrant a bit of experimentation and exploration. 

One interesting point is the question, whether a different kind of crypto should result in a new BEEFY protocol, including it's own engine id. Or whether using different gossip topics etc. is enough. Basically, the implications of running multiple BEEFY instances, using different crypto have not been investigated so far.

Sure, we can make `BeefyKeystore` generic right now by adding a type parameter. But so what? It will (or actually should) not be used and might turn out to be we wrong approach, anyway. IMO, it will take a lot more to make configurable BEEFY crypto work seamless.

The signature related unit tests don't use `BeefyKeystore` because it is `beefy_gadget` private. That could be changed and the tests could be using `BeefyKeystore`.

So the tl;dr version of this PR is: do less, in order to enable more.
