### PR TITLE
Immediate authority change

### DIFF
--- a/beefy-pallet/src/lib.rs
+++ b/beefy-pallet/src/lib.rs
@@ -105,24 +105,20 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn change_authorities(new: Vec<T::AuthorityId>, queued: Vec<T::AuthorityId>) {
-		// As in GRANDPA, we trigger a validator set change only if the the validator
-		// set has actually changed.
-		if new != Self::authorities() {
-			<Authorities<T>>::put(&new);
+		<Authorities<T>>::put(&new);
 
-			let next_id = Self::validator_set_id() + 1u64;
-			<ValidatorSetId<T>>::put(next_id);
+		let next_id = Self::validator_set_id() + 1u64;
+		<ValidatorSetId<T>>::put(next_id);
 
-			let log: DigestItem<T::Hash> = DigestItem::Consensus(
-				BEEFY_ENGINE_ID,
-				ConsensusLog::AuthoritiesChange(ValidatorSet {
-					validators: new,
-					id: next_id,
-				})
-				.encode(),
-			);
-			<frame_system::Pallet<T>>::deposit_log(log);
-		}
+		let log: DigestItem<T::Hash> = DigestItem::Consensus(
+			BEEFY_ENGINE_ID,
+			ConsensusLog::AuthoritiesChange(ValidatorSet {
+				validators: new,
+				id: next_id,
+			})
+			.encode(),
+		);
+		<frame_system::Pallet<T>>::deposit_log(log);
 
 		<NextAuthorities<T>>::put(&queued);
 	}


### PR DESCRIPTION
According to the `SessionHandler::on_new_session()` documentation `changed is true whenever any of the session keys or underlying economic identities or weightings behind those keys has changed.`

We enact such a change now immediately, 

I changed this PR to a draft, because the issue it is supposed to address might have an unrelated root cause. So, this PR might actually not be needed.