### PR TITLE
Rename AuthorityId to BeefyId to avoid type conflict in UI

### DIFF
--- a/beefy-node/runtime/src/lib.rs
+++ b/beefy-node/runtime/src/lib.rs
@@ -230,7 +230,7 @@ impl pallet_grandpa::Config for Runtime {
 }
 
 impl pallet_beefy::Config for Runtime {
-	type AuthorityId = BeefyId;
+	type BeefyId = BeefyId;
 }
 
 parameter_types! {

--- a/beefy-pallet/src/mock.rs
+++ b/beefy-pallet/src/mock.rs
@@ -86,7 +86,7 @@ impl frame_system::Config for Test {
 }
 
 impl pallet_beefy::Config for Test {
-	type AuthorityId = BeefyId;
+	type BeefyId = BeefyId;
 }
 
 parameter_types! {


### PR DESCRIPTION
CC @jacogr the type defintion should be:
`"BeefyId": "[u8;33]"`

This fixes displaying `beefy::authorities()` in the Chain State tab in the UI.