### PR TITLE
Fixing trie generation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "beefy-primitives",
  "env_logger 0.8.4",
  "hex",
+ "hex-literal",
  "libsecp256k1 0.5.0",
  "log",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,6 @@ dependencies = [
  "sp-core",
  "sp-trie",
  "structopt",
- "trie-db",
 ]
 
 [[package]]

--- a/beefy-cli/Cargo.toml
+++ b/beefy-cli/Cargo.toml
@@ -17,7 +17,6 @@ structopt = "0.3.21"
 
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
-trie-db = "0.22"
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/beefy-cli/Cargo.toml
+++ b/beefy-cli/Cargo.toml
@@ -18,3 +18,7 @@ structopt = "0.3.21"
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
 trie-db = "0.22"
+
+[dev-dependencies]
+hex-literal = "0.3"
+


### PR DESCRIPTION
For some reason I don't recall the trie generation was done using `trie_db::trie_visit`.

This resulted in:
1. Incorrect merkle roots (I've compared generated values with on-chain values of Rococo).
2. Incorrect proofs - the proofs were non-inclusion proofs, cause the key values were not matching the ones that end up in the trie using `trie_visit` method.

This PR populates the trie manually and the resulting trie root matches the on-chain one. Also proofs generated with the CLI are verifiable with the respective command.

Closes #197 
Most likely also solves: https://github.com/Snowfork/polkadot-ethereum/pull/429#issuecomment-861903861