### PR TITLE
Additional initial authority id's

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,38 @@ In case your BEEFY keys are using the wrong cryptographic scheme, you will see a
 
 ## Running BEEFY
 
-Currently the easiest way to see BEEFY in action is to run a single dev node like so:
+Currently the easiest way to run BEEFY is to use a 3-node local testnet using `beefy-node`. We will call those nodes `Alice`, `Bob` and
+`Charlie`. Each node will use the built-in development account with the same name, i.e. node `Alice` will use the `Alice` development
+account and so on. Each of the three accounts has been configured as an initial authority at genesis. So, we are using three validators
+for our testnet.
+
+`Alice` is our bootnode is is started like so:
 
 ```
-$ RUST_LOG=beefy=trace ./target/debug/beefy-node --tmp --dev --alice --validator
+$ RUST_LOG=beefy=trace ./target/debug/beefy-node --tmp --alice -d /tmp/alice
 ```
 
-Expect additional (more useful) deployment options to be added soon.
+`Bob` is started like so:
+
+```
+RUST_LOG=beefy=trace ./target/debug/beefy-node --tmp --bob --port 30334 --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
+```
+
+`Charlie` is started like so:
+
+```
+RUST_LOG=beefy=trace ./target/debug/beefy-node --tmp --charlie --port 30334 --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
+```
+
+Note that `Alice` is using a persistent DB located under `/tmp/alice`. Instead, `Bob` and `Charlie` are using an ephemeral DB, as indicated by the `--tmp` CLI option. The reason for this is the `ALICE_BOOTNODE_ID_HERE` placeholder.
+
+Once we start our `Alice` bootnode, a so called `local node id` will be generated. This local node id is derived from the public key of the `Alice` account. This local node id has to be used instead of the `ALICE_BOOTNODE_ID_HERE` placeholder with the `Bob` and `Charlie` nodes.
+Since `Alice` is using a persistent DB, once we restart `Alice`, the **same** local node id will be used, basically the one that was persisted
+to the DB. This allows us to stop and restart our development testnet without having to copy and paste the local node id again at each restart
+of `Alice`.
+
+The log entry for the `Alice` local node id will look something like:
+
+```
+2021-06-21 09:03:37.257  INFO main sub-libp2p: 🏷 Local node identity is: 12D3KooWRyuPfN5r81CZvjvLutM4v2NsaYwwXcnkXY8exsUhFs5i
+```

--- a/README.md
+++ b/README.md
@@ -117,22 +117,22 @@ for our testnet.
 `Alice` is our bootnode is is started like so:
 
 ```
-$ RUST_LOG=beefy=trace ./target/debug/beefy-node --tmp --alice -d /tmp/alice
+$ RUST_LOG=beefy=trace ./target/debug/beefy-node --alice -d /tmp/alice
 ```
 
 `Bob` is started like so:
 
 ```
-RUST_LOG=beefy=trace ./target/debug/beefy-node --tmp --bob --port 30334 --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
+RUST_LOG=beefy=trace ./target/debug/beefy-node --bob --port 30334 -d/ tmp/bob --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
 ```
 
 `Charlie` is started like so:
 
 ```
-RUST_LOG=beefy=trace ./target/debug/beefy-node --tmp --charlie --port 30334 --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
+RUST_LOG=beefy=trace ./target/debug/beefy-node --charlie --port 30334 -d /tmp/charlie --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
 ```
 
-Note that `Alice` is using a persistent DB located under `/tmp/alice`. Instead, `Bob` and `Charlie` are using an ephemeral DB, as indicated by the `--tmp` CLI option. The reason for this is the `ALICE_BOOTNODE_ID_HERE` placeholder.
+Note that all nodes are using a persistent DB located under `/tmp/xxx`. For `Bob` and `Charlie` this is not strictly necessary, however. The reason for this is the `ALICE_BOOTNODE_ID_HERE` placeholder.
 
 Once we start our `Alice` bootnode, a so called `local node id` will be generated. This local node id is derived from the public key of the `Alice` account. This local node id has to be used instead of the `ALICE_BOOTNODE_ID_HERE` placeholder with the `Bob` and `Charlie` nodes.
 Since `Alice` is using a persistent DB, once we restart `Alice`, the **same** local node id will be used, basically the one that was persisted

--- a/README.md
+++ b/README.md
@@ -117,30 +117,20 @@ for our testnet.
 `Alice` is our bootnode is is started like so:
 
 ```
-$ RUST_LOG=beefy=trace ./target/debug/beefy-node --alice -d /tmp/alice
+$ RUST_LOG=beefy=trace ./target/debug/beefy-node --tmp --alice
 ```
 
 `Bob` is started like so:
 
 ```
-RUST_LOG=beefy=trace ./target/debug/beefy-node --bob --port 30334 -d/ tmp/bob --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
+RUST_LOG=beefy=trace ./target/debug/beefy-node --tmp --bob
 ```
 
 `Charlie` is started like so:
 
 ```
-RUST_LOG=beefy=trace ./target/debug/beefy-node --charlie --port 30334 -d /tmp/charlie --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
+RUST_LOG=beefy=trace ./target/debug/beefy-node --tmp --charlie
 ```
 
-Note that all nodes are using a persistent DB located under `/tmp/xxx`. For `Bob` and `Charlie` this is not strictly necessary, however. The reason for this is the `ALICE_BOOTNODE_ID_HERE` placeholder.
-
-Once we start our `Alice` bootnode, a so called `local node id` will be generated. This local node id is derived from the public key of the `Alice` account. This local node id has to be used instead of the `ALICE_BOOTNODE_ID_HERE` placeholder with the `Bob` and `Charlie` nodes.
-Since `Alice` is using a persistent DB, once we restart `Alice`, the **same** local node id will be used, basically the one that was persisted
-to the DB. This allows us to stop and restart our development testnet without having to copy and paste the local node id again at each restart
-of `Alice`.
-
-The log entry for the `Alice` local node id will look something like:
-
-```
-2021-06-21 09:03:37.257  INFO main sub-libp2p: 🏷 Local node identity is: 12D3KooWRyuPfN5r81CZvjvLutM4v2NsaYwwXcnkXY8exsUhFs5i
-```
+Note that the examples above use an ephemeral DB due to the `--tmp` CLI option. If you want a persistent DB, use `--/tmp/[node-name]`
+instead. Replace `node-name` with the actual node name (e.g. `alice`) in order to assure separate dirctories for the DB.

--- a/beefy-gadget/src/gossip.rs
+++ b/beefy-gadget/src/gossip.rs
@@ -35,7 +35,7 @@ use beefy_primitives::{
 use crate::keystore::BeefyKeystore;
 
 // Limit BEEFY gossip by keeping only a bound number of voting rounds alive.
-const MAX_LIVE_GOSSIP_ROUNDS: usize = 5;
+const MAX_LIVE_GOSSIP_ROUNDS: usize = 3;
 
 /// Gossip engine messages topic
 pub(crate) fn topic<B: Block>() -> B::Hash

--- a/beefy-gadget/src/gossip.rs
+++ b/beefy-gadget/src/gossip.rs
@@ -91,19 +91,6 @@ where
 		}
 	}
 
-	/// Scratch a live voting round.
-	///
-	/// This should be called after `round` has been concluded.
-	pub(crate) fn scratch_round(&self, round: NumberFor<B>) {
-		trace!(target: "beefy", "🥩 About to scratch round #{}", round);
-
-		let mut live_rounds = self.live_rounds.write();
-
-		if let Ok(idx) = live_rounds.binary_search(&round) {
-			live_rounds.remove(idx);
-		}
-	}
-
 	fn is_live(live_rounds: &[NumberFor<B>], round: NumberFor<B>) -> bool {
 		live_rounds.binary_search(&round).is_ok()
 	}

--- a/beefy-gadget/src/gossip.rs
+++ b/beefy-gadget/src/gossip.rs
@@ -74,7 +74,7 @@ where
 
 	/// Note a live voting round
 	///
-	/// This should be called, if we cast a vote for `round`.
+	/// This should be called, in order to keep tabs on `round`.
 	pub(crate) fn note_round(&self, round: NumberFor<B>) {
 		trace!(target: "beefy", "🥩 About to note round #{}", round);
 

--- a/beefy-gadget/src/worker.rs
+++ b/beefy-gadget/src/worker.rs
@@ -287,8 +287,6 @@ where
 
 				info!(target: "beefy", "🥩 Round #{} concluded, committed: {:?}.", round.1, signed_commitment);
 
-				self.gossip_validator.scratch_round(round.1);
-
 				if self
 					.backend
 					.append_justification(

--- a/beefy-gadget/src/worker.rs
+++ b/beefy-gadget/src/worker.rs
@@ -287,6 +287,8 @@ where
 
 				info!(target: "beefy", "🥩 Round #{} concluded, committed: {:?}.", round.1, signed_commitment);
 
+				self.gossip_validator.scratch_round(round.1);
+
 				if self
 					.backend
 					.append_justification(

--- a/beefy-node/node/src/chain_spec.rs
+++ b/beefy-node/node/src/chain_spec.rs
@@ -54,15 +54,21 @@ pub fn development_config() -> Result<ChainSpec, String> {
 			testnet_genesis(
 				wasm_binary,
 				// Initial PoA authorities
-				vec![authority_keys_from_seed("Alice")],
+				vec![
+					authority_keys_from_seed("Alice"),
+					authority_keys_from_seed("Boc"),
+					authority_keys_from_seed("Charlie"),
+				],
 				// Sudo account
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
 				// Pre-funded accounts
 				vec![
 					get_account_id_from_seed::<sr25519::Public>("Alice"),
 					get_account_id_from_seed::<sr25519::Public>("Bob"),
+					get_account_id_from_seed::<sr25519::Public>("Charlie"),
 					get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
 				],
 				true,
 			)

--- a/beefy-node/node/src/chain_spec.rs
+++ b/beefy-node/node/src/chain_spec.rs
@@ -56,7 +56,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
 				// Initial PoA authorities
 				vec![
 					authority_keys_from_seed("Alice"),
-					authority_keys_from_seed("Boc"),
+					authority_keys_from_seed("Bob"),
 					authority_keys_from_seed("Charlie"),
 				],
 				// Sudo account


### PR DESCRIPTION
- Add `Bob` and `Charlie` as initial authority id's to the chain spec for `beefy-node`. This allows for a much more useful local test net based on `beefy-node`. The instructions for how to run such a test net have been updated as well.

- Improve some trace points