### PR TITLE
Use LocalKeystore for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ name = "beefy-gadget"
 version = "0.1.0"
 dependencies = [
  "beefy-primitives",
+ "beefy-test",
  "futures 0.3.15",
  "hex",
  "log",

--- a/beefy-gadget/Cargo.toml
+++ b/beefy-gadget/Cargo.toml
@@ -34,3 +34,5 @@ beefy-primitives = { path = "../beefy-primitives" }
 
 [dev-dependencies]
 sc-network-test = { git = "https://github.com/paritytech/substrate", branch = "master" }
+
+beefy-test = { path = "../beefy-test" }

--- a/beefy-gadget/src/keystore.rs
+++ b/beefy-gadget/src/keystore.rs
@@ -67,11 +67,7 @@ impl BeefyKeystore {
 	///
 	/// Return the message signature or an error in case of failure.
 	pub fn sign(&self, public: &Public, message: &[u8]) -> Result<Signature, error::Error> {
-		let store = if let Some(store) = self.0.clone() {
-			store
-		} else {
-			return Err(error::Error::Keystore("no Keystore".to_string()));
-		};
+		let store = keystore!(self);
 
 		let msg = keccak_256(message);
 		let public = public.as_ref();

--- a/beefy-gadget/src/keystore.rs
+++ b/beefy-gadget/src/keystore.rs
@@ -238,20 +238,16 @@ mod tests {
 
 		// test keys
 		let _ = add_key(TEST_TYPE, Some(Keyring::Alice.to_seed().as_str()));
-
 		let _ = add_key(TEST_TYPE, Some(Keyring::Bob.to_seed().as_str()));
 
 		let _ = add_key(TEST_TYPE, None);
-
 		let _ = add_key(TEST_TYPE, None);
 
 		// BEEFY keys
 		let _ = add_key(KEY_TYPE, Some(Keyring::Dave.to_seed().as_str()));
-
 		let _ = add_key(KEY_TYPE, Some(Keyring::Eve.to_seed().as_str()));
 
 		let key1: crypto::Public = add_key(KEY_TYPE, None).into();
-
 		let key2: crypto::Public = add_key(KEY_TYPE, None).into();
 
 		let store: BeefyKeystore = Some(store).into();


### PR DESCRIPTION
Turns out that `sc_keystore::LocalKeystore` and `sp_keystore::testing::KeyStore` are quite different from an implementation point of view. So, using the test version of the key store is basically pointless.

Hence, all `BeefyKeystore` test are now using `LocalKeystore`, i.e. the "real" key store.

Also introduced a `public_keys()` function to `BeefyKeystore` which will be used in an upcoming PR for key store sanity checking.