### PR TITLE
Cache known votes in gossip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,7 @@ version = "0.1.0"
 dependencies = [
  "beefy-primitives",
  "beefy-test",
+ "fnv",
  "futures 0.3.15",
  "hex",
  "log",

--- a/beefy-gadget/Cargo.toml
+++ b/beefy-gadget/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
+fnv = "1.0.6"
 futures = "0.3"
 hex = "0.4"
 log = "0.4"

--- a/beefy-gadget/src/gossip.rs
+++ b/beefy-gadget/src/gossip.rs
@@ -125,7 +125,7 @@ where
 		mut data: &[u8],
 	) -> ValidationResult<B::Hash> {
 		if let Ok(msg) = VoteMessage::<MmrRootHash, NumberFor<B>, Public, Signature>::decode(&mut data) {
-			let msg_hash = twox_64(&data);
+			let msg_hash = twox_64(data);
 			let round = msg.commitment.block_number;
 
 			// Verify general usefulness of the message.

--- a/beefy-gadget/src/gossip.rs
+++ b/beefy-gadget/src/gossip.rs
@@ -191,8 +191,14 @@ where
 
 #[cfg(test)]
 mod tests {
-	use super::{GossipValidator, MAX_LIVE_GOSSIP_ROUNDS};
+	use crate::keystore::BeefyKeystore;
+
+	use super::*;
+	use beefy_primitives::{crypto::Signature, Commitment, MmrRootHash, VoteMessage, KEY_TYPE};
+	use beefy_test::Keyring;
+	use sc_keystore::LocalKeystore;
 	use sc_network_test::Block;
+	use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 
 	#[test]
 	fn note_round_works() {
@@ -275,5 +281,80 @@ mod tests {
 		assert!(GossipValidator::<Block>::is_live(&live, &3u64));
 		assert!(GossipValidator::<Block>::is_live(&live, &7u64));
 		assert!(GossipValidator::<Block>::is_live(&live, &10u64));
+	}
+
+	struct TestContext;
+	impl<B: sp_runtime::traits::Block> ValidatorContext<B> for TestContext {
+		fn broadcast_topic(&mut self, _topic: B::Hash, _force: bool) {
+			todo!()
+		}
+
+		fn broadcast_message(&mut self, _topic: B::Hash, _message: Vec<u8>, _force: bool) {
+			todo!()
+		}
+
+		fn send_message(&mut self, _who: &sc_network::PeerId, _message: Vec<u8>) {
+			todo!()
+		}
+
+		fn send_topic(&mut self, _who: &sc_network::PeerId, _topic: B::Hash, _force: bool) {
+			todo!()
+		}
+	}
+
+	fn sign_commitment<BN: Encode, P: Encode>(who: &Keyring, commitment: &Commitment<BN, P>) -> Signature {
+		let store: SyncCryptoStorePtr = std::sync::Arc::new(LocalKeystore::in_memory());
+		SyncCryptoStore::ecdsa_generate_new(&*store, KEY_TYPE, Some(&who.to_seed())).unwrap();
+		let beefy_keystore: BeefyKeystore = Some(store).into();
+
+		beefy_keystore.sign(&who.public(), &commitment.encode()).unwrap()
+	}
+
+	#[test]
+	fn should_avoid_verifying_signatures_twice() {
+		let gv = GossipValidator::<Block>::new();
+		let sender = sc_network::PeerId::random();
+		let mut context = TestContext;
+		let commitment = Commitment {
+			payload: MmrRootHash::default(),
+			block_number: 3_u64,
+			validator_set_id: 0,
+		};
+		let signature = sign_commitment(&Keyring::Alice, &commitment);
+		let vote = VoteMessage {
+			commitment,
+			id: Keyring::Alice.public(),
+			signature,
+		};
+
+		gv.note_round(3u64);
+		gv.note_round(7u64);
+		gv.note_round(10u64);
+
+		// first time the cache should be populated.
+		let res = gv.validate(&mut context, &sender, &vote.encode());
+		assert!(matches!(res, ValidationResult::ProcessAndKeep(_)));
+		assert_eq!(
+			gv.known_votes
+				.read()
+				.get(&vote.commitment.block_number)
+				.map(|x| x.len()),
+			Some(1)
+		);
+
+		// second time we should hit the cache
+		let res = gv.validate(&mut context, &sender, &vote.encode());
+		assert!(matches!(res, ValidationResult::ProcessAndKeep(_)));
+
+		// next we should quickly reject if the round is not live.
+		gv.note_round(11_u64);
+		gv.note_round(12_u64);
+		assert!(!GossipValidator::<Block>::is_live(
+			&*gv.known_votes.read(),
+			&vote.commitment.block_number
+		));
+
+		let res = gv.validate(&mut context, &sender, &vote.encode());
+		assert!(matches!(res, ValidationResult::Discard));
 	}
 }


### PR DESCRIPTION
This PR introduces a cache for known votes (ideally I think we should be avoiding the `RwLock` stuff). Each time we receive a valid vote for a particular round, we keep it's hash in gossip to quickly approve such votes in the future if they are coming from other peers. AFAICT the `sc_network_gossip` does de-duplicate incoming messages, but only if they are coming from the same peer, not necessarily if they are sent by multiple peers.

My guess is that receiving & verifying the same votes from multiple peers might be causing the high CPU usage we are observing on Rococo, so this cache should alleviate the issue before we implement #212 and #182. 

Also in `validate` function we quickly reject messages that are for old rounds. Previously we were always verifying and accepting such messages, but later on they were considered "expired" by the gossip subsystem, hence removed.