### PR TITLE
Add Charlie as initial authority

### DIFF
--- a/beefy-node/node/src/chain_spec.rs
+++ b/beefy-node/node/src/chain_spec.rs
@@ -99,7 +99,11 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 			testnet_genesis(
 				wasm_binary,
 				// Initial PoA authorities
-				vec![authority_keys_from_seed("Alice"), authority_keys_from_seed("Bob")],
+				vec![
+					authority_keys_from_seed("Alice"),
+					authority_keys_from_seed("Bob"),
+					authority_keys_from_seed("Charlie"),
+				],
 				// Sudo account
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
 				// Pre-funded accounts


### PR DESCRIPTION
- Add `Charlie` as an initial PoA authority for the local test net configuration as well.