### PR TITLE
Introduce test network and support components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "async-trait",
+ "beefy-gadget",
  "beefy-primitives",
  "futures 0.3.16",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,8 +600,17 @@ name = "beefy-test"
 version = "0.1.0"
 dependencies = [
  "beefy-primitives",
+ "futures 0.3.16",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-consensus",
+ "sp-consensus",
  "sp-core",
+ "sp-runtime",
+ "sp-tracing",
  "strum 0.21.0",
+ "substrate-test-runtime",
+ "substrate-test-runtime-client",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,9 +601,12 @@ version = "0.1.0"
 dependencies = [
  "beefy-primitives",
  "futures 0.3.16",
+ "libp2p 0.38.0",
+ "log",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
+ "sc-network",
  "sp-consensus",
  "sp-core",
  "sp-runtime",
@@ -3020,6 +3023,26 @@ dependencies = [
  "libp2p-wasm-ext",
  "libp2p-websocket",
  "libp2p-yamux",
+ "parity-multiaddr",
+ "parking_lot 0.11.1",
+ "pin-project 1.0.8",
+ "smallvec 1.6.1",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebbb17eece4aec5bb970880c73825c16ca59ca05a4e41803751e68c7e5f0c618"
+dependencies = [
+ "atomic",
+ "bytes 1.0.1",
+ "futures 0.3.16",
+ "lazy_static",
+ "libp2p-core",
+ "libp2p-swarm",
+ "libp2p-swarm-derive",
  "parity-multiaddr",
  "parking_lot 0.11.1",
  "pin-project 1.0.8",
@@ -5535,7 +5558,7 @@ dependencies = [
  "fdlimit",
  "futures 0.3.16",
  "hex",
- "libp2p",
+ "libp2p 0.37.1",
  "log",
  "names",
  "parity-scale-codec",
@@ -5970,7 +5993,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "hex",
  "ip_network",
- "libp2p",
+ "libp2p 0.37.1",
  "linked-hash-map",
  "linked_hash_set",
  "log",
@@ -6009,7 +6032,7 @@ source = "git+https://github.com/paritytech/substrate?branch=master#e0d13b58e128
 dependencies = [
  "futures 0.3.16",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.37.1",
  "log",
  "lru",
  "sc-network",
@@ -6028,7 +6051,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.16",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.37.1",
  "log",
  "parking_lot 0.11.1",
  "rand 0.7.3",
@@ -6082,7 +6105,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=master#e0d13b58e1281514866e93a04a7232c05f79da45"
 dependencies = [
  "futures 0.3.16",
- "libp2p",
+ "libp2p 0.37.1",
  "log",
  "serde_json",
  "sp-utils",
@@ -6265,7 +6288,7 @@ source = "git+https://github.com/paritytech/substrate?branch=master#e0d13b58e128
 dependencies = [
  "chrono",
  "futures 0.3.16",
- "libp2p",
+ "libp2p 0.37.1",
  "log",
  "parking_lot 0.11.1",
  "pin-project 1.0.8",
@@ -6830,7 +6853,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.16",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.37.1",
  "log",
  "parity-scale-codec",
  "parking_lot 0.11.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,14 +599,20 @@ dependencies = [
 name = "beefy-test"
 version = "0.1.0"
 dependencies = [
+ "async-std",
+ "async-trait",
  "beefy-primitives",
  "futures 0.3.16",
+ "futures-core",
  "libp2p 0.38.0",
  "log",
+ "parking_lot 0.11.1",
+ "rand 0.8.4",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
  "sc-network",
+ "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-runtime",

--- a/beefy-test/Cargo.toml
+++ b/beefy-test/Cargo.toml
@@ -6,15 +6,23 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
+sc-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sc-network = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
 substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 substrate-test-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
 beefy-primitives = { path = "../beefy-primitives" }
 
+futures = { version = "0.3" }
+libp2p = { version = "0.38", default-features = false }
+log = { version = "0.4" }
 strum = { version = "0.21", features = ["derive"] }
 
 [dev-dependencies]
@@ -25,4 +33,3 @@ sp-tracing = { git = "https://github.com/paritytech/substrate.git", branch = "ma
 sc-client-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sc-block-builder = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
-futures = { version = "0.3" }

--- a/beefy-test/Cargo.toml
+++ b/beefy-test/Cargo.toml
@@ -19,6 +19,7 @@ sc-network = { git = "https://github.com/paritytech/substrate.git", branch = "ma
 substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 substrate-test-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
+beefy-gadget = { path = "../beefy-gadget" }
 beefy-primitives = { path = "../beefy-primitives" }
 
 async-std = { version = "1.9" }

--- a/beefy-test/Cargo.toml
+++ b/beefy-test/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
@@ -20,16 +21,15 @@ substrate-test-runtime = { git = "https://github.com/paritytech/substrate.git", 
 
 beefy-primitives = { path = "../beefy-primitives" }
 
+async-std = { version = "1.9" }
+async-trait = { version = "0.1" }
 futures = { version = "0.3" }
+futures-core = { version = "0.3" }
 libp2p = { version = "0.38", default-features = false }
 log = { version = "0.4" }
+parking_lot = { version = "0.11" }
+rand = { version = "0.8" }
 strum = { version = "0.21", features = ["derive"] }
 
 [dev-dependencies]
-sp-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-tracing = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-
-sc-client-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-block-builder = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-

--- a/beefy-test/Cargo.toml
+++ b/beefy-test/Cargo.toml
@@ -6,8 +6,23 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-strum = { version = "0.21", features = ["derive"] }
-
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
+sc-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+substrate-test-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+
 beefy-primitives = { path = "../beefy-primitives" }
+
+strum = { version = "0.21", features = ["derive"] }
+
+[dev-dependencies]
+sp-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-tracing = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+
+sc-client-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sc-block-builder = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+
+futures = { version = "0.3" }

--- a/beefy-test/src/client.rs
+++ b/beefy-test/src/client.rs
@@ -27,6 +27,7 @@ use substrate_test_runtime_client::{Backend, TestClient, TestClientBuilder, Test
 
 use crate::import::AnyBlockImport;
 
+/// A test client.
 #[derive(Clone)]
 pub struct Client {
 	pub(crate) inner: Arc<TestClient>,
@@ -35,6 +36,7 @@ pub struct Client {
 }
 
 impl Client {
+	/// Return a new test client.
 	pub fn new() -> Client {
 		let backend = Arc::new(Backend::new_test(std::u32::MAX, std::u64::MAX));
 		let builder = TestClientBuilder::with_backend(backend);

--- a/beefy-test/src/client.rs
+++ b/beefy-test/src/client.rs
@@ -1,0 +1,162 @@
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use sc_consensus::LongestChain;
+
+use substrate_test_runtime::Block;
+use substrate_test_runtime_client::{Backend, TestClient, TestClientBuilder, TestClientBuilderExt};
+
+#[derive(Clone)]
+pub struct Client {
+	pub(crate) inner: Arc<TestClient>,
+	pub(crate) backend: Arc<Backend>,
+	pub(crate) chain: LongestChain<substrate_test_runtime_client::Backend, Block>,
+}
+
+impl Client {
+	pub fn new() -> Client {
+		let backend = Arc::new(Backend::new_test(std::u32::MAX, std::u64::MAX));
+		let builder = TestClientBuilder::with_backend(backend);
+		let backend = builder.backend();
+
+		let (client, chain) = builder.build_with_longest_chain();
+
+		Client {
+			inner: Arc::new(client),
+			backend,
+			chain,
+		}
+	}
+}
+
+impl Default for Client {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::Client;
+
+	use sp_consensus::block_import::BlockOrigin;
+	use sp_runtime::{ConsensusEngineId, Justification, Justifications};
+
+	use sc_block_builder::BlockBuilderProvider;
+	use sc_client_api::HeaderBackend;
+
+	use substrate_test_runtime_client::prelude::*;
+
+	use futures::executor::{self};
+
+	#[test]
+	fn import() {
+		sp_tracing::try_init_simple();
+
+		let mut client = Client::new();
+
+		let block = client
+			.inner
+			.new_block(Default::default())
+			.unwrap()
+			.build()
+			.unwrap()
+			.block;
+
+		executor::block_on(client.inner.import(BlockOrigin::File, block)).unwrap();
+
+		let info = client.inner.info();
+
+		assert_eq!(1, info.best_number);
+		assert_eq!(0, info.finalized_number);
+	}
+
+	#[test]
+	fn import_blocks() {
+		sp_tracing::try_init_simple();
+
+		let mut client = Client::new();
+
+		for _ in 0..10 {
+			let block = client
+				.inner
+				.new_block(Default::default())
+				.unwrap()
+				.build()
+				.unwrap()
+				.block;
+
+			executor::block_on(client.inner.import(BlockOrigin::File, block)).unwrap();
+		}
+
+		let info = client.inner.info();
+
+		assert_eq!(10, info.best_number);
+		assert_eq!(0, info.finalized_number);
+	}
+
+	#[test]
+	fn import_finalized() {
+		sp_tracing::try_init_simple();
+
+		let mut client = Client::new();
+
+		let block = client
+			.inner
+			.new_block(Default::default())
+			.unwrap()
+			.build()
+			.unwrap()
+			.block;
+
+		executor::block_on(client.inner.import_as_final(BlockOrigin::File, block)).unwrap();
+
+		let info = client.inner.info();
+
+		assert_eq!(1, info.best_number);
+		assert_eq!(1, info.finalized_number);
+	}
+
+	#[test]
+	fn import_justification() {
+		sp_tracing::try_init_simple();
+
+		const ENGINE_ID: ConsensusEngineId = *b"SMPL";
+
+		let mut client = Client::new();
+
+		let block = client
+			.inner
+			.new_block(Default::default())
+			.unwrap()
+			.build()
+			.unwrap()
+			.block;
+
+		let j: Justification = (ENGINE_ID, vec![1, 2, 3]);
+
+		let j = Justifications::from(j);
+
+		executor::block_on(client.inner.import_justified(BlockOrigin::File, block, j)).unwrap();
+
+		let info = client.inner.info();
+
+		assert_eq!(1, info.best_number);
+		assert_eq!(1, info.finalized_number);
+	}
+}

--- a/beefy-test/src/client.rs
+++ b/beefy-test/src/client.rs
@@ -75,7 +75,7 @@ impl Client {
 	}
 
 	/// Return a clone of the inner test client
-	pub fn inner(&self) -> Arc<TestClient> {
+	pub fn as_inner(&self) -> Arc<TestClient> {
 		self.inner.clone()
 	}
 

--- a/beefy-test/src/import.rs
+++ b/beefy-test/src/import.rs
@@ -1,0 +1,223 @@
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{collections::HashMap, sync::Arc};
+
+use sc_client_api::backend::TransactionFor;
+use sp_blockchain::well_known_cache_keys;
+use sp_consensus::{
+	block_import::JustificationImport,
+	import_queue::{CacheKeyId, Verifier},
+	BlockCheckParams, BlockImport, BlockImportParams, BlockOrigin, ForkChoiceStrategy, ImportResult,
+};
+use sp_core::H256;
+use sp_runtime::{
+	generic::{BlockId, OpaqueDigestItemId},
+	traits::{Block, Header, NumberFor},
+	Justification, Justifications,
+};
+
+use substrate_test_runtime_client::{runtime, Backend};
+
+use futures::lock::Mutex as AsyncMutex;
+use parking_lot::Mutex;
+
+use crate::Client;
+
+pub trait AnyTransaction:
+	BlockImport<runtime::Block, Transaction = TransactionFor<Backend, runtime::Block>, Error = sp_consensus::Error>
+	+ Send
+	+ Sync
+	+ Clone
+{
+	// empty
+}
+
+impl<T> AnyTransaction for T
+where
+	T: BlockImport<runtime::Block, Transaction = TransactionFor<Backend, runtime::Block>, Error = sp_consensus::Error>
+		+ Send
+		+ Sync
+		+ Clone,
+{
+	// empty
+}
+
+/// Implements [`sp_consensus::block_import::BlockImport`] for the any transaction type.
+#[derive(Clone)]
+pub struct AnyBlockImport<BI> {
+	inner: BI,
+}
+
+impl<I> AnyBlockImport<I> {
+	pub fn new(inner: I) -> Self {
+		Self { inner }
+	}
+}
+
+#[async_trait::async_trait]
+impl<BI> BlockImport<runtime::Block> for AnyBlockImport<BI>
+where
+	BI: BlockImport<runtime::Block, Error = sp_consensus::Error> + Send + Sync,
+	BI::Transaction: Send,
+{
+	type Error = sp_consensus::Error;
+	type Transaction = ();
+
+	/// Check block preconditions
+	async fn check_block(&mut self, block: BlockCheckParams<runtime::Block>) -> Result<ImportResult, Self::Error> {
+		self.inner.check_block(block).await
+	}
+
+	/// Import a block
+	async fn import_block(
+		&mut self,
+		block: BlockImportParams<runtime::Block, Self::Transaction>,
+		cache: HashMap<CacheKeyId, Vec<u8>>,
+	) -> Result<ImportResult, Self::Error> {
+		self.inner
+			.import_block(block.clear_storage_changes_and_mutate(), cache)
+			.await
+	}
+}
+
+/// A Verifier that accepts all justifications and passes them on for import.
+///
+/// Block finality and fork choice strategy are configurable.
+#[derive(Clone)]
+pub struct PassThroughVerifier {
+	finalized: bool,
+	fork_choice: ForkChoiceStrategy,
+}
+
+impl PassThroughVerifier {
+	pub fn new(finalized: bool) -> Self {
+		Self {
+			finalized,
+			fork_choice: ForkChoiceStrategy::LongestChain,
+		}
+	}
+}
+
+#[async_trait::async_trait]
+impl<B> Verifier<B> for PassThroughVerifier
+where
+	B: Block,
+{
+	async fn verify(
+		&mut self,
+		origin: BlockOrigin,
+		header: B::Header,
+		justifications: Option<Justifications>,
+		body: Option<Vec<B::Extrinsic>>,
+	) -> Result<(BlockImportParams<B, ()>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
+		let maybe_keys = header
+			.digest()
+			.log(|l| l.try_as_raw(OpaqueDigestItemId::Consensus(b"smpl")))
+			.map(|l| vec![(well_known_cache_keys::AUTHORITIES, l.to_vec())]);
+
+		let mut import = BlockImportParams::new(origin, header);
+		import.body = body;
+		import.finalized = self.finalized;
+		import.justifications = justifications;
+		import.fork_choice = Some(self.fork_choice);
+
+		Ok((import, maybe_keys))
+	}
+}
+
+/// A [`sp_consensus::block_import::JustificationImport`] implementation that
+/// will always finalize the imported block.
+pub struct Finalizer(pub Client);
+
+#[async_trait::async_trait]
+impl JustificationImport<runtime::Block> for Finalizer {
+	type Error = sp_consensus::Error;
+
+	async fn on_start(&mut self) -> Vec<(H256, NumberFor<runtime::Block>)> {
+		Vec::new()
+	}
+
+	async fn import_justification(
+		&mut self,
+		hash: H256,
+		_number: NumberFor<runtime::Block>,
+		justification: Justification,
+	) -> Result<(), Self::Error> {
+		self.0
+			.finalize_block(BlockId::Hash(hash), Some(justification), true)
+			.map_err(|_| sp_consensus::Error::InvalidJustification)
+	}
+}
+
+/// Verifier implementation for tracking failed verifications
+pub struct TrackingVerifier<B>
+where
+	B: Block,
+{
+	inner: Arc<AsyncMutex<Box<dyn Verifier<B>>>>,
+	failed: Arc<Mutex<HashMap<B::Hash, String>>>,
+}
+
+impl<B> TrackingVerifier<B>
+where
+	B: Block,
+{
+	pub fn new(verifier: impl Verifier<B> + 'static) -> Self {
+		TrackingVerifier {
+			inner: Arc::new(AsyncMutex::new(Box::new(verifier))),
+			failed: Default::default(),
+		}
+	}
+}
+
+#[async_trait::async_trait]
+impl<B> Verifier<B> for TrackingVerifier<B>
+where
+	B: Block,
+{
+	async fn verify(
+		&mut self,
+		origin: BlockOrigin,
+		header: B::Header,
+		justifications: Option<Justifications>,
+		body: Option<Vec<B::Extrinsic>>,
+	) -> Result<(BlockImportParams<B, ()>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
+		let hash = header.hash();
+
+		self.inner
+			.lock()
+			.await
+			.verify(origin, header, justifications, body)
+			.await
+			.map_err(|e| {
+				self.failed.lock().insert(hash, e.clone());
+				e
+			})
+	}
+}
+
+impl<B> Clone for TrackingVerifier<B>
+where
+	B: Block,
+{
+	fn clone(&self) -> Self {
+		Self {
+			inner: self.inner.clone(),
+			failed: self.failed.clone(),
+		}
+	}
+}

--- a/beefy-test/src/import.rs
+++ b/beefy-test/src/import.rs
@@ -32,10 +32,12 @@ use sp_runtime::{
 
 use substrate_test_runtime_client::{runtime, Backend};
 
-use futures::lock::Mutex as AsyncMutex;
-use parking_lot::Mutex;
+use beefy_primitives::BEEFY_ENGINE_ID;
 
 use crate::Client;
+
+use futures::lock::Mutex as AsyncMutex;
+use parking_lot::Mutex;
 
 pub trait AnyTransaction:
 	BlockImport<runtime::Block, Transaction = TransactionFor<Backend, runtime::Block>, Error = sp_consensus::Error>
@@ -126,7 +128,7 @@ where
 	) -> Result<(BlockImportParams<B, ()>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
 		let maybe_keys = header
 			.digest()
-			.log(|l| l.try_as_raw(OpaqueDigestItemId::Consensus(b"smpl")))
+			.log(|l| l.try_as_raw(OpaqueDigestItemId::Consensus(&BEEFY_ENGINE_ID)))
 			.map(|l| vec![(well_known_cache_keys::AUTHORITIES, l.to_vec())]);
 
 		let mut import = BlockImportParams::new(origin, header);

--- a/beefy-test/src/lib.rs
+++ b/beefy-test/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+mod client;
 mod keyring;
 
+pub use client::Client;
 pub use keyring::Keyring;

--- a/beefy-test/src/lib.rs
+++ b/beefy-test/src/lib.rs
@@ -22,4 +22,5 @@ mod peer;
 
 pub use client::Client;
 pub use keyring::Keyring;
+pub use network::{Network, NetworkProvider};
 pub use peer::{Peer, PeerConfig};

--- a/beefy-test/src/lib.rs
+++ b/beefy-test/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod client;
 mod keyring;
+mod peer;
 
 pub use client::Client;
 pub use keyring::Keyring;

--- a/beefy-test/src/lib.rs
+++ b/beefy-test/src/lib.rs
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+#![warn(missing_docs)]
+
+//! `BEEFY` test utilities.
+
 mod client;
 mod import;
 mod keyring;

--- a/beefy-test/src/lib.rs
+++ b/beefy-test/src/lib.rs
@@ -15,8 +15,11 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 mod client;
+mod import;
 mod keyring;
+mod network;
 mod peer;
 
 pub use client::Client;
 pub use keyring::Keyring;
+pub use peer::{Peer, PeerConfig};

--- a/beefy-test/src/network.rs
+++ b/beefy-test/src/network.rs
@@ -49,11 +49,15 @@ use futures::{prelude::*, FutureExt};
 use futures_core::future::BoxFuture;
 use log::trace;
 
+/// An implementation of this trait will provide a test network.
 pub trait NetworkProvider {
+	/// Associated [`sp_consensus::import_queue::Verfier`]
 	type Verifier: Verifier<Block> + Clone + 'static;
 
+	/// Associated [`sp_consensus::import::BlockImport`]
 	type BlockImport: BlockImport<Block, Error = sp_consensus::Error> + Clone + Send + Sync + 'static;
 
+	/// Associated [`sp_consensus::import_queue::Link`]
 	type Link: Default;
 
 	/// Implement this function to return a mock network customized for your needs.

--- a/beefy-test/src/network.rs
+++ b/beefy-test/src/network.rs
@@ -1,0 +1,377 @@
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{
+	sync::Arc,
+	task::{Context, Poll},
+};
+
+use sc_client_api::BlockchainEvents;
+use sc_network::{
+	block_request_handler::BlockRequestHandler,
+	config::{
+		build_multiaddr, EmptyTransactionPool, NetworkConfiguration, NonDefaultSetConfig, ProtocolConfig, ProtocolId,
+		Role, SetConfig, SyncMode, TransportConfig,
+	},
+	light_client_requests::handler::LightClientRequestHandler,
+	state_request_handler::StateRequestHandler,
+	NetworkWorker,
+};
+use sp_consensus::{
+	block_import::BlockImport,
+	block_validation::DefaultBlockAnnounceValidator,
+	import_queue::{BasicQueue, BoxJustificationImport, Verifier},
+};
+
+use substrate_test_runtime_client::runtime::Block;
+
+use futures::{prelude::*, FutureExt};
+use futures_core::future::BoxFuture;
+use log::trace;
+
+use crate::{
+	import::{AnyBlockImport, Finalizer, PassThroughVerifier, TrackingVerifier},
+	Client, Peer, PeerConfig,
+};
+
+pub trait NetworkProvider {
+	type Verifier: Verifier<Block> + Clone + 'static;
+
+	type BlockImport: BlockImport<Block, Error = sp_consensus::Error> + Clone + Send + Sync + 'static;
+
+	type Link: Default;
+
+	/// Implement this function to return a mock network customized for your needs.
+	fn new() -> Self;
+
+	/// Implement this function to return a block import verifier customized for your needs.
+	fn verifier(&self, client: Client, config: &ProtocolConfig, link: &Self::Link) -> Self::Verifier;
+
+	/// Implement this function to return a block import implementation customized for your needs.
+	fn block_import(
+		&self,
+		client: Client,
+	) -> (
+		AnyBlockImport<Self::BlockImport>,
+		Option<BoxJustificationImport<Block>>,
+		Self::Link,
+	);
+
+	/// Implment this function to return a mutable reference to peer `i`
+	fn peer(&mut self, i: usize) -> &mut Peer<Self::Link, Self::BlockImport>;
+
+	/// Implement this function to return a reference to the vector of peers
+	fn peers(&self) -> &Vec<Peer<Self::Link, Self::BlockImport>>;
+
+	/// Implement this function to mutate all peers with a `mutator`
+	fn mutate_peers<M>(&mut self, mutator: M)
+	where
+		M: FnOnce(&mut Vec<Peer<Self::Link, Self::BlockImport>>);
+
+	#[allow(dead_code)]
+	/// Add a peer with `config` peer configuration
+	fn add_peer(&mut self, config: PeerConfig) {
+		let client = Client::new();
+
+		let (block_import, justification_import, link) = self.block_import(client.clone());
+
+		let verifier = self.verifier(client.clone(), &Default::default(), &link);
+		let verifier = TrackingVerifier::new(verifier);
+
+		let import_queue = Box::new(BasicQueue::new(
+			verifier.clone(),
+			Box::new(block_import.clone()),
+			justification_import,
+			&sp_core::testing::TaskExecutor::new(),
+			None,
+		));
+
+		let protocol_id = ProtocolId::from("falso-protocol-name");
+
+		let block_request_protocol_config = {
+			let (handler, protocol_config) = BlockRequestHandler::new(&protocol_id, client.inner(), 50);
+			self.spawn_task(handler.run().boxed());
+			protocol_config
+		};
+
+		let state_request_protocol_config = {
+			let (handler, protocol_config) = StateRequestHandler::new(&protocol_id, client.inner(), 50);
+			self.spawn_task(handler.run().boxed());
+			protocol_config
+		};
+
+		let light_client_request_protocol_config = {
+			let (handler, protocol_config) = LightClientRequestHandler::new(&protocol_id, client.inner());
+			self.spawn_task(handler.run().boxed());
+			protocol_config
+		};
+
+		let net_cfg = network_config(config.clone());
+
+		let network = NetworkWorker::new(sc_network::config::Params {
+			role: if config.is_authority {
+				Role::Authority
+			} else {
+				Role::Full
+			},
+			executor: None,
+			transactions_handler_executor: Box::new(|tsk| {
+				async_std::task::spawn(tsk);
+			}),
+			network_config: net_cfg.clone(),
+			chain: client.inner(),
+			on_demand: None,
+			transaction_pool: Arc::new(EmptyTransactionPool),
+			protocol_id,
+			import_queue,
+			block_announce_validator: Box::new(DefaultBlockAnnounceValidator),
+			metrics_registry: None,
+			block_request_protocol_config,
+			state_request_protocol_config,
+			light_client_request_protocol_config,
+		})
+		.unwrap();
+
+		self.mutate_peers(move |peers| {
+			for peer in peers.iter_mut() {
+				peer.network
+					.add_known_address(*network.service().local_peer_id(), net_cfg.listen_addresses[0].clone());
+			}
+
+			let block_import_stream = Box::pin(client.inner().import_notification_stream().fuse());
+
+			let finality_notification_stream = Box::pin(client.inner().finality_notification_stream().fuse());
+
+			peers.push(Peer {
+				link,
+				client: client.clone(),
+				verifier,
+				block_import,
+				select_chain: Some(client.chain()),
+				network,
+				block_import_stream,
+				finality_notification_stream,
+				listen_addr: net_cfg.listen_addresses[0].clone(),
+			});
+		});
+	}
+
+	/// Spawn background tasks
+	fn spawn_task(&self, f: BoxFuture<'static, ()>) {
+		async_std::task::spawn(f);
+	}
+
+	/// Poll the network. Polling will process all pending events
+	///
+	/// Note that we merge multiple pending finality notifications together and only
+	/// act on the last one. This is the same behaviour as (indirectly) exhibited by
+	/// [`sc_service::build_network()`]
+	fn poll(&mut self, cx: &mut Context) {
+		self.mutate_peers(|peers| {
+			for (i, peer) in peers.iter_mut().enumerate() {
+				trace!(target: "falso", "Polling peer {}: {}", i, peer.id());
+
+				if let Poll::Ready(()) = peer.network.poll_unpin(cx) {
+					panic!("Network worker terminated unexpectedly")
+				}
+
+				trace!(target: "falso", "Done polling peer {}: {}", i, peer.id());
+
+				// process pending block import notifications
+				while let Poll::Ready(Some(imported)) = peer.block_import_stream.as_mut().poll_next(cx) {
+					peer.network.service().announce_block(imported.hash, None);
+				}
+
+				// merge pending finality notifications, only process the last one
+				let mut last = None;
+
+				while let Poll::Ready(Some(finalized)) = peer.finality_notification_stream.as_mut().poll_next(cx) {
+					last = Some(finalized);
+				}
+
+				if let Some(finalized) = last {
+					peer.network.on_block_finalized(finalized.hash, finalized.header);
+				}
+			}
+		});
+	}
+
+	/// Poll the network, until all peers are connected to each other.
+	fn poll_connected(&mut self, cx: &mut Context) -> Poll<()> {
+		self.poll(cx);
+
+		let others = self.peers().len() - 1;
+
+		if self.peers().iter().all(|p| p.connected_peers() == others) {
+			return Poll::Ready(());
+		}
+
+		Poll::Pending
+	}
+
+	/// Poll the network until all peers have synced
+	fn poll_synced(&mut self, cx: &mut Context) -> Poll<()> {
+		self.poll(cx);
+
+		// we keep polling until all peers agree on the best block
+		let mut best = None;
+
+		for peer in self.peers().iter() {
+			if peer.is_syncing() || peer.network.num_queued_blocks() != 0 {
+				return Poll::Pending;
+			}
+
+			if peer.network.num_sync_requests() != 0 {
+				return Poll::Pending;
+			}
+
+			match (best, peer.client.info().best_hash) {
+				(None, hash) => best = Some(hash),
+				(Some(ref a), ref b) if a == b => {}
+				(Some(_), _) => return Poll::Pending,
+			}
+		}
+
+		Poll::Ready(())
+	}
+
+	/// Block until all peers are connected to each other
+	fn block_until_connected(&mut self) {
+		futures::executor::block_on(futures::future::poll_fn::<(), _>(|cx| self.poll_connected(cx)))
+	}
+
+	/// Block until all peers finished syncing
+	fn block_until_synced(&mut self) {
+		futures::executor::block_on(futures::future::poll_fn::<(), _>(|cx| self.poll_synced(cx)))
+	}
+}
+
+// Return a network configuration for a new peer
+fn network_config(config: PeerConfig) -> NetworkConfiguration {
+	let mut net_cfg = NetworkConfiguration::new("falso-node", "falso-client", Default::default(), None);
+
+	net_cfg.sync_mode = SyncMode::Full;
+	net_cfg.transport = TransportConfig::MemoryOnly;
+	net_cfg.listen_addresses = vec![build_multiaddr![Memory(rand::random::<u64>())]];
+	net_cfg.allow_non_globals_in_dht = true;
+	net_cfg.default_peers_set = SetConfig::default();
+	net_cfg.extra_sets = config
+		.protocols
+		.into_iter()
+		.map(|p| NonDefaultSetConfig {
+			notifications_protocol: p,
+			fallback_names: Vec::new(),
+			max_notification_size: 1024 * 1024,
+			set_config: Default::default(),
+		})
+		.collect();
+
+	net_cfg
+}
+
+/// A simple default network
+pub struct Network {
+	peers: Vec<Peer<(), Client>>,
+}
+
+impl NetworkProvider for Network {
+	type Verifier = PassThroughVerifier;
+	type BlockImport = Client;
+	type Link = ();
+
+	fn new() -> Self {
+		Network { peers: Vec::new() }
+	}
+
+	fn verifier(&self, _client: Client, _config: &ProtocolConfig, _link: &Self::Link) -> Self::Verifier {
+		PassThroughVerifier::new(false)
+	}
+
+	fn block_import(
+		&self,
+		client: Client,
+	) -> (
+		AnyBlockImport<Self::BlockImport>,
+		Option<BoxJustificationImport<Block>>,
+		Self::Link,
+	) {
+		(
+			client.as_block_import(),
+			Some(Box::new(Finalizer(client))),
+			Default::default(),
+		)
+	}
+
+	fn peer(&mut self, i: usize) -> &mut Peer<Self::Link, Self::BlockImport> {
+		&mut self.peers[i]
+	}
+
+	fn peers(&self) -> &Vec<Peer<Self::Link, Self::BlockImport>> {
+		&self.peers
+	}
+
+	fn mutate_peers<M>(&mut self, mutator: M)
+	where
+		M: FnOnce(&mut Vec<Peer<Self::Link, Self::BlockImport>>),
+	{
+		mutator(&mut self.peers);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{Network, NetworkProvider, PeerConfig};
+
+	#[test]
+	fn new_network() {
+		sp_tracing::try_init_simple();
+
+		let mut net = Network::new();
+
+		assert_eq!(net.peers.len(), 0);
+
+		net.add_peer(PeerConfig::default());
+		net.add_peer(PeerConfig::default());
+
+		assert_eq!(net.peers.len(), 2);
+
+		let id1 = net.peer(0).id();
+		let id2 = net.peer(1).id();
+
+		assert_ne!(id1, id2);
+		assert_eq!(0, net.peer(0).connected_peers());
+		assert_eq!(0, net.peer(1).connected_peers());
+	}
+
+	#[test]
+	fn connect_all_peers() {
+		sp_tracing::try_init_simple();
+
+		let mut net = Network::new();
+
+		for _ in 0..5 {
+			net.add_peer(PeerConfig::default());
+		}
+
+		assert!(net.peers().iter().all(|p| p.connected_peers() == 0));
+
+		net.block_until_connected();
+
+		let others = net.peers().len() - 1;
+
+		assert!(net.peers().iter().all(|p| p.connected_peers() == others));
+	}
+}

--- a/beefy-test/src/network.rs
+++ b/beefy-test/src/network.rs
@@ -107,19 +107,19 @@ pub trait NetworkProvider {
 		let protocol_id = ProtocolId::from(BEEFY_PROTOCOL_NAME);
 
 		let block_request_protocol_config = {
-			let (handler, protocol_config) = BlockRequestHandler::new(&protocol_id, client.inner(), 50);
+			let (handler, protocol_config) = BlockRequestHandler::new(&protocol_id, client.as_inner(), 50);
 			self.spawn_task(handler.run().boxed());
 			protocol_config
 		};
 
 		let state_request_protocol_config = {
-			let (handler, protocol_config) = StateRequestHandler::new(&protocol_id, client.inner(), 50);
+			let (handler, protocol_config) = StateRequestHandler::new(&protocol_id, client.as_inner(), 50);
 			self.spawn_task(handler.run().boxed());
 			protocol_config
 		};
 
 		let light_client_request_protocol_config = {
-			let (handler, protocol_config) = LightClientRequestHandler::new(&protocol_id, client.inner());
+			let (handler, protocol_config) = LightClientRequestHandler::new(&protocol_id, client.as_inner());
 			self.spawn_task(handler.run().boxed());
 			protocol_config
 		};
@@ -137,7 +137,7 @@ pub trait NetworkProvider {
 				async_std::task::spawn(tsk);
 			}),
 			network_config: net_cfg.clone(),
-			chain: client.inner(),
+			chain: client.as_inner(),
 			on_demand: None,
 			transaction_pool: Arc::new(EmptyTransactionPool),
 			protocol_id,
@@ -156,9 +156,9 @@ pub trait NetworkProvider {
 					.add_known_address(*network.service().local_peer_id(), net_cfg.listen_addresses[0].clone());
 			}
 
-			let block_import_stream = Box::pin(client.inner().import_notification_stream().fuse());
+			let block_import_stream = Box::pin(client.as_inner().import_notification_stream().fuse());
 
-			let finality_notification_stream = Box::pin(client.inner().finality_notification_stream().fuse());
+			let finality_notification_stream = Box::pin(client.as_inner().finality_notification_stream().fuse());
 
 			peers.push(Peer {
 				link,

--- a/beefy-test/src/peer.rs
+++ b/beefy-test/src/peer.rs
@@ -1,0 +1,136 @@
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+
+use std::{borrow::Cow, pin::Pin};
+
+use sc_block_builder::BlockBuilderProvider;
+use sc_client_api::{FinalityNotification, HeaderBackend};
+use sc_consensus::LongestChain;
+use sc_network::{Multiaddr, NetworkWorker};
+use sp_consensus::BlockOrigin;
+use sp_core::H256;
+use sp_runtime::{generic::BlockId, traits::Header};
+
+use substrate_test_runtime::{Block, Hash};
+use substrate_test_runtime_client::{Backend, ClientBlockImportExt};
+
+use crate::Client;
+
+use futures::{
+	executor::{self},
+	Stream,
+};
+use libp2p::PeerId;
+use log::trace;
+
+type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
+
+#[derive(Default, Clone)]
+/// Configuration for a network peer
+pub struct PeerConfig {
+	/// Set of notification protocols a peer should participate in.
+	pub protocols: Vec<Cow<'static, str>>,
+	/// Is peer an authority or a regualr node
+	pub is_authority: bool,
+}
+
+/// A network peer
+pub struct Peer {
+	pub(crate) client: Client,
+	pub(crate) select_chain: Option<LongestChain<Backend, Block>>,
+	pub(crate) network: NetworkWorker<Block, Hash>,
+	pub(crate) finality_notification_stream: BoxStream<FinalityNotification<Block>>,
+	pub(crate) listen_addr: Multiaddr,
+}
+
+impl Peer {
+	/// Return unique peer id
+	pub fn id(&self) -> PeerId {
+		*self.network.service().local_peer_id()
+	}
+
+	/// Return a reference to the network, i.e. the peer's network worker
+	pub fn network(&self) -> &NetworkWorker<Block, Hash> {
+		&self.network
+	}
+
+	/// Return a reference to the peer's client
+	pub fn client(&self) -> &Client {
+		&self.client
+	}
+
+	/// Return the number of peers this peer is connected to
+	pub fn connected_peers(&self) -> usize {
+		self.network.num_connected_peers()
+	}
+
+	/// Return whether peer is currently syncing
+	pub fn is_syncing(&self) -> bool {
+		self.network.service().is_major_syncing()
+	}
+
+	/// Add a new block at best block.
+	///
+	/// Adding a new block will push the block through the block import pipeline.
+	pub fn add_block(&mut self) -> Hash {
+		let best = self.client.inner.info().best_hash;
+
+		self.blocks_at(BlockId::Hash(best), 1)
+	}
+
+	/// Add `count` blocks at best block
+	///
+	/// Adding blocks will push them through the block import pipeline.
+	pub fn add_blocks(&mut self, count: usize) -> Hash {
+		let best = self.client.inner.info().best_hash;
+
+		self.blocks_at(BlockId::Hash(best), count)
+	}
+
+	fn blocks_at(&mut self, at: BlockId<Block>, count: usize) -> H256 {
+		let mut client = self.client.inner.clone();
+
+		let mut best: H256 = [0u8; 32].into();
+
+		for _ in 0..count {
+			let block = client
+				.new_block(Default::default())
+				.expect("failed create a new block")
+				.build()
+				.expect("failed to build block")
+				.block;
+
+			let hash = block.header.hash();
+
+			trace!(target: "beefy-test", "Block {} #{} parent: {}", hash, block.header.number, at);
+
+			executor::block_on(client.import(BlockOrigin::File, block)).expect("block import failed");
+
+			self.network.service().announce_block(hash, None);
+
+			best = hash;
+		}
+
+		self.network.new_best_block_imported(
+			best,
+			*client.header(&BlockId::Hash(best)).ok().flatten().unwrap().number(),
+		);
+
+		best
+	}
+}

--- a/beefy-test/src/peer.rs
+++ b/beefy-test/src/peer.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
-
 use std::{borrow::Cow, pin::Pin};
 
 use sc_block_builder::{BlockBuilder, BlockBuilderProvider};
@@ -53,6 +51,9 @@ pub struct PeerConfig {
 }
 
 /// A network peer
+///
+/// Note that all named fields are acutally used in order to add a new peer.
+#[allow(dead_code)]
 pub struct Peer<L, BI> {
 	pub(crate) link: L,
 	pub(crate) client: Client,

--- a/beefy-test/src/peer.rs
+++ b/beefy-test/src/peer.rs
@@ -120,7 +120,7 @@ where
 	where
 		F: FnMut(BlockBuilder<Block, TestClient, Backend>) -> Block,
 	{
-		let mut client = self.client.inner();
+		let mut client = self.client.as_inner();
 
 		let mut best: H256 = [0u8; 32].into();
 


### PR DESCRIPTION
This PR adds various building blocks in order to write unit tests which require either a network, client or backend.

To this end, the following structures have benn added to `beefy-test`
- `Client`
- `Peer`
- `Network`

The above components in it's current form should be considered a starting point. They provide what is needed to get going and will be enhanced / adapted based on the needs of concrete unit test cases.