### PR TITLE
sp-io update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,56 +38,37 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
-version = "0.3.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
  "generic-array 0.14.4",
 ]
 
 [[package]]
 name = "aes"
-version = "0.5.0"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "aes-soft",
- "aesni",
- "block-cipher",
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures 0.2.1",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.7.0"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0301c9e9c443494d970a07885e8cf3e587bae8356a1d5abd0999068413f7205f"
+checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
  "aead",
  "aes",
- "block-cipher",
+ "cipher",
+ "ctr",
  "ghash",
  "subtle 2.4.1",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
-dependencies = [
- "block-cipher",
- "byteorder",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aesni"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
-dependencies = [
- "block-cipher",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -765,15 +746,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-cipher"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
-dependencies = [
- "generic-array 0.14.4",
-]
-
-[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,24 +928,26 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.5.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244fbce0d47e97e8ef2f63b81d5e05882cb518c68531eb33194990d7b7e85845"
+checksum = "f08493fa7707effc63254c66c6ea908675912493cd67952eda23c09fae2610b1"
 dependencies = [
- "stream-cipher",
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures 0.2.1",
  "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf18d374d66df0c05cdddd528a7db98f78c28e2519b120855c4f84c5027b1f5"
+checksum = "b6547abe025f4027edacd9edaa357aded014eecec42a5070d9b885c3c334aba2"
 dependencies = [
  "aead",
  "chacha20",
+ "cipher",
  "poly1305",
- "stream-cipher",
  "zeroize",
 ]
 
@@ -997,15 +971,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff0e3bc0b6446b3f9663c1a6aba6ef06c5aeaa1bc92bd18077be337198ab9768"
 dependencies = [
  "multibase",
- "multihash",
+ "multihash 0.13.2",
  "unsigned-varint 0.5.1",
 ]
 
 [[package]]
 name = "cipher"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array 0.14.4",
 ]
@@ -1110,10 +1084,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.2.0"
+name = "cpufeatures"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cranelift-bforest"
@@ -1201,7 +1178,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "itertools 0.10.1",
+ "itertools",
  "log",
  "serde",
  "smallvec 1.6.1",
@@ -1353,6 +1330,15 @@ checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1769,7 +1755,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1787,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1806,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "Inflector",
  "chrono",
@@ -1832,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1847,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "14.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1858,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1884,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1896,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.0.0",
@@ -1908,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1918,7 +1904,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1935,7 +1921,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1949,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2204,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.3.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug 0.3.0",
  "polyval",
@@ -2391,17 +2377,6 @@ checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac 0.8.0",
  "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
-dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.4",
- "hmac 0.7.1",
 ]
 
 [[package]]
@@ -2731,15 +2706,6 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
@@ -2971,9 +2937,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libloading"
@@ -3003,9 +2969,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.37.1"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08053fbef67cd777049ef7a95ebaca2ece370b4ed7712c3fa404d69a88cb741b"
+checksum = "9004c06878ef8f3b4b4067e69a140d87ed20bf777287f82223e49713b36ee433"
 dependencies = [
  "atomic",
  "bytes 1.0.1",
@@ -3033,7 +2999,7 @@ dependencies = [
  "libp2p-wasm-ext",
  "libp2p-websocket",
  "libp2p-yamux",
- "parity-multiaddr",
+ "multiaddr",
  "parking_lot 0.11.1",
  "pin-project 1.0.8",
  "smallvec 1.6.1",
@@ -3042,9 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554d3e7e9e65f939d66b75fd6a4c67f258fe250da61b91f46c545fc4a89b51d9"
+checksum = "af9b4abdeaa420593a297c8592f63fad4234f4b88dc9343b8fd8e736c35faa59"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -3054,11 +3020,11 @@ dependencies = [
  "futures 0.3.16",
  "futures-timer 3.0.2",
  "lazy_static",
- "libsecp256k1 0.3.5",
+ "libsecp256k1 0.5.0",
  "log",
- "multihash",
+ "multiaddr",
+ "multihash 0.14.0",
  "multistream-select",
- "parity-multiaddr",
  "parking_lot 0.11.1",
  "pin-project 1.0.8",
  "prost",
@@ -3076,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-deflate"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2181a641cd15f9b6ba71b1335800f309012a0a97a29ffaabbbf40e9d3d58f08"
+checksum = "66097fccc0b7f8579f90a03ea76ba6196332ea049fd07fd969490a06819dcdc8"
 dependencies = [
  "flate2",
  "futures 0.3.16",
@@ -3087,9 +3053,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e63dab8b5ff35e0c101a3e51e843ba782c07bbb1682f5fd827622e0d02b98b"
+checksum = "58ff08b3196b85a17f202d80589e93b1660a574af67275706657fdc762e42c32"
 dependencies = [
  "async-std-resolver",
  "futures 0.3.16",
@@ -3101,9 +3067,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48a9b570f6766301d9c4aa00fce3554cad1598e2f466debbc4dde909028417cf"
+checksum = "404eca8720967179dac7a5b4275eb91f904a53859c69ca8d018560ad6beb214f"
 dependencies = [
  "cuckoofilter",
  "fnv",
@@ -3119,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.30.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b0c8506a6ec3344b9e706d7c7a6dba826f8ede735cfe13dde12a8c263c4af9"
+checksum = "b1cc48709bcbc3a3321f08a73560b4bbb4166a7d56f6fdb615bc775f4f91058e"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "base64 0.13.0",
@@ -3145,9 +3111,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f668f00efd9883e8b7bcc582eaf0164615792608f886f6577da18bcbeea0a46"
+checksum = "a7b61f6cf07664fb97016c318c4d4512b3dd4cc07238607f3f0163245f99008e"
 dependencies = [
  "futures 0.3.16",
  "libp2p-core",
@@ -3161,9 +3127,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07312ebe5ee4fd2404447a0609814574df55c65d4e20838b957bbd34907d820"
+checksum = "50ed78489c87924235665a0ab345b298ee34dff0f7ad62c0ba6608b2144fb75e"
 dependencies = [
  "arrayvec 0.5.2",
  "asynchronous-codec 0.6.0",
@@ -3187,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.30.2"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efa70c1c3d2d91237f8546e27aeb85e287d62c066a7b4f3ea6a696d43ced714"
+checksum = "a29e6cbc2a24b8471b6567e580a0e8e7b70a6d0f0ea2be0844d1e842d7d4fa33"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -3208,9 +3174,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e9b544335d1ed30af71daa96edbefadef6f19c7a55f078b9fc92c87163105d"
+checksum = "313d9ea526c68df4425f580024e67a9d3ffd49f2c33de5154b1f5019816f7a99"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
@@ -3226,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36db0f0db3b0433f5b9463f1c0cd9eadc0a3734a9170439ce501ff99733a88bd"
+checksum = "3f1db7212f342b6ba7c981cc40e31f76e9e56cb48e65fa4c142ecaca5839523e"
 dependencies = [
  "bytes 1.0.1",
  "curve25519-dalek 3.2.0",
@@ -3238,7 +3204,7 @@ dependencies = [
  "log",
  "prost",
  "prost-build",
- "rand 0.7.3",
+ "rand 0.8.4",
  "sha2 0.9.5",
  "snow",
  "static_assertions",
@@ -3248,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4bfaffac63bf3c7ec11ed9d8879d455966ddea7e78ee14737f0b6dce0d1cd1"
+checksum = "2482cfd9eb0b7a0baaf3e7b329dc4f2785181a161b1a47b7192f8d758f54a439"
 dependencies = [
  "futures 0.3.16",
  "libp2p-core",
@@ -3263,9 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8c37b4d2a075b4be8442760a5f8c037180f0c8dd5b5734b9978ab868b3aa11"
+checksum = "13b4783e5423870b9a5c199f65a7a3bc66d86ab56b2b9beebf3c338d889cf8e4"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
@@ -3280,9 +3246,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-pnet"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce3374f3b28162db9d3442c9347c4f14cb01e8290052615c7d341d40eae0599"
+checksum = "07cb4dd4b917e5b40ddefe49b96b07adcd8d342e0317011d175b7b2bb1dcc974"
 dependencies = [
  "futures 0.3.16",
  "log",
@@ -3294,9 +3260,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8786aca3f18671d8776289706a5521f6c9124a820f69e358de214b9939440d"
+checksum = "0133f6cfd81cdc16e716de2982e012c62e6b9d4f12e41967b3ee361051c622aa"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
@@ -3317,9 +3283,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdbe172f08e6d0f95fa8634e273d4c4268c4063de2e33e7435194b0130c62e3"
+checksum = "06cdae44b6821466123af93cbcdec7c9e6ba9534a8af9cdc296446d39416d241"
 dependencies = [
  "async-trait",
  "bytes 1.0.1",
@@ -3337,9 +3303,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e04d8e1eef675029ec728ba14e8d0da7975d84b6679b699b4ae91a1de9c3a92"
+checksum = "7083861341e1555467863b4cd802bea1e8c4787c0f7b5110097d0f1f3248f9a9"
 dependencies = [
  "either",
  "futures 0.3.16",
@@ -3353,9 +3319,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365b0a699fea5168676840567582a012ea297b1ca02eee467e58301b9c9c5eed"
+checksum = "ab8cb308d4fc854869f5abb54fdab0833d2cf670d407c745849dc47e6e08d79c"
 dependencies = [
  "quote",
  "syn",
@@ -3363,9 +3329,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1a27d21c477951799e99d5c105d78868258502ce092988040a808d5a19bbd9"
+checksum = "79edd26b6b4bb5feee210dcda562dca186940dfecb0024b979c3f50824b3bf28"
 dependencies = [
  "async-io",
  "futures 0.3.16",
@@ -3380,9 +3346,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-uds"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd6564bb3b7ff203661ccbb69003c2b551e34cef974f2d6c6a28306a12170b5"
+checksum = "280e793440dd4e9f273d714f4497325c72cddb0fe85a49f9a03c88f41dd20182"
 dependencies = [
  "async-std",
  "futures 0.3.16",
@@ -3392,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d413e4cf9b8e5dfbcd2a60d3dc5a3391308bdb463684093d4f67137b7113de"
+checksum = "f553b7140fad3d7a76f50497b0ea591e26737d9607428a75509fc191e4d1b1f6"
 dependencies = [
  "futures 0.3.16",
  "js-sys",
@@ -3406,9 +3372,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cace60995ef6f637e4752cccbb2590f6bc358e8741a0d066307636c69a4b3a74"
+checksum = "ddf99dcbf5063e9d59087f61b1e85c686ceab2f5abedb472d32288065c0e5e27"
 dependencies = [
  "either",
  "futures 0.3.16",
@@ -3424,9 +3390,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35da42cfc6d5cb0dcf3ad6881bc68d146cdf38f98655e09e33fbba4d13eabc4"
+checksum = "214cc0dd9c37cbed27f0bb1eba0c41bbafdb93a8be5e9d6ae1e6b4b42cd044bf"
 dependencies = [
  "futures 0.3.16",
  "libp2p-core",
@@ -3449,17 +3415,20 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
+checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
 dependencies = [
  "arrayref",
- "crunchy",
- "digest 0.8.1",
- "hmac-drbg 0.2.0",
+ "base64 0.12.3",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
  "rand 0.7.3",
- "sha2 0.8.2",
- "subtle 2.4.1",
+ "serde",
+ "sha2 0.9.5",
  "typenum",
 ]
 
@@ -3472,7 +3441,7 @@ dependencies = [
  "arrayref",
  "base64 0.12.3",
  "digest 0.9.0",
- "hmac-drbg 0.3.0",
+ "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
@@ -3818,6 +3787,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
+name = "multiaddr"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ee4ea82141951ac6379f964f71b20876d43712bea8faf6dd1a375e08a46499"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder",
+ "data-encoding",
+ "multihash 0.14.0",
+ "percent-encoding 2.1.0",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.7.0",
+ "url 2.2.2",
+]
+
+[[package]]
 name = "multibase"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3843,6 +3830,19 @@ dependencies = [
  "sha2 0.9.5",
  "sha3",
  "unsigned-varint 0.5.1",
+]
+
+[[package]]
+name = "multihash"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array 0.14.4",
+ "multihash-derive",
+ "sha2 0.9.5",
+ "unsigned-varint 0.7.0",
 ]
 
 [[package]]
@@ -4083,7 +4083,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4113,7 +4113,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4136,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4194,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4216,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-benchmarking",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4282,7 +4282,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4295,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4313,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4346,7 +4346,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4369,24 +4369,6 @@ dependencies = [
  "memmap2",
  "parking_lot 0.11.1",
  "rand 0.8.4",
-]
-
-[[package]]
-name = "parity-multiaddr"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58341485071825827b7f03cf7efd1cb21e6a709bea778fb50227fd45d2f361b4"
-dependencies = [
- "arrayref",
- "bs58",
- "byteorder",
- "data-encoding",
- "multihash",
- "percent-encoding 2.1.0",
- "serde",
- "static_assertions",
- "unsigned-varint 0.7.0",
- "url 2.2.2",
 ]
 
 [[package]]
@@ -4762,21 +4744,23 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.6.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7456bc1ad2d4cf82b3a016be4c2ac48daf11bf990c1603ebd447fe6f30fca8"
+checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
- "cpuid-bool",
+ "cpufeatures 0.2.1",
+ "opaque-debug 0.3.0",
  "universal-hash",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.4.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
- "cpuid-bool",
+ "cfg-if 1.0.0",
+ "cpufeatures 0.2.1",
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
@@ -4879,9 +4863,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes 1.0.1",
  "prost-derive",
@@ -4889,13 +4873,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes 1.0.1",
  "heck",
- "itertools 0.9.0",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
@@ -4907,12 +4891,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -4920,9 +4904,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes 1.0.1",
  "prost",
@@ -5438,9 +5422,9 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399f290ffc409596022fce5ea5d4138184be4784f2b28c62c59f0d8389059a15"
+checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
 dependencies = [
  "cipher",
 ]
@@ -5457,7 +5441,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "log",
  "sp-core",
@@ -5468,7 +5452,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "futures 0.3.16",
  "futures-timer 3.0.2",
@@ -5491,7 +5475,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5507,7 +5491,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5523,7 +5507,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -5534,7 +5518,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -5572,7 +5556,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5606,7 +5590,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5635,7 +5619,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -5660,7 +5644,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5692,7 +5676,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -5721,11 +5705,11 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "derive_more",
  "lazy_static",
- "libsecp256k1 0.3.5",
+ "libsecp256k1 0.6.0",
  "log",
  "parity-scale-codec",
  "parity-wasm 0.42.2",
@@ -5750,7 +5734,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -5767,7 +5751,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5782,7 +5766,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -5802,7 +5786,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5843,7 +5827,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.16",
@@ -5861,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5881,7 +5865,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5900,7 +5884,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5955,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "futures 0.3.16",
  "futures-timer 3.0.2",
@@ -5972,7 +5956,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-std",
  "async-trait",
@@ -6001,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -6029,7 +6013,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "futures 0.3.16",
  "libp2p",
@@ -6042,7 +6026,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -6051,7 +6035,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "futures 0.3.16",
  "hash-db",
@@ -6086,7 +6070,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "derive_more",
  "futures 0.3.16",
@@ -6111,7 +6095,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "futures 0.1.31",
  "jsonrpc-core",
@@ -6129,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "directories",
@@ -6197,7 +6181,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6212,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "chrono",
  "futures 0.3.16",
@@ -6232,7 +6216,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6269,7 +6253,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -6280,7 +6264,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "derive_more",
  "futures 0.3.16",
@@ -6309,7 +6293,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "derive_more",
  "futures 0.3.16",
@@ -6522,7 +6506,7 @@ checksum = "1a0c8611594e2ab4ebbf06ec7cbbf0a99450b8570e96cbf5188b5d5f6ef18d81"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpufeatures 0.1.5",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -6547,7 +6531,7 @@ checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpufeatures 0.1.5",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -6648,17 +6632,17 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "snow"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795dd7aeeee24468e5a32661f6d27f7b5cbed802031b2d7640c7b10f8fb2dd50"
+checksum = "6142f7c25e94f6fd25a32c3348ec230df9109b463f59c8c7acc4bd34936babb7"
 dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.4",
+ "rand_core 0.6.3",
  "ring",
- "rustc_version 0.2.3",
+ "rustc_version 0.3.3",
  "sha2 0.9.5",
  "subtle 2.4.1",
  "x25519-dalek",
@@ -6704,7 +6688,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "hash-db",
  "log",
@@ -6721,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.0.0",
@@ -6733,7 +6717,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6745,7 +6729,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6759,7 +6743,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6771,7 +6755,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6783,7 +6767,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "futures 0.3.16",
  "log",
@@ -6801,7 +6785,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -6827,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6844,7 +6828,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "merlin",
@@ -6866,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "parity-scale-codec",
  "sp-arithmetic",
@@ -6876,7 +6860,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6888,7 +6872,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6901,7 +6885,7 @@ dependencies = [
  "hex",
  "impl-serde",
  "lazy_static",
- "libsecp256k1 0.3.5",
+ "libsecp256k1 0.6.0",
  "log",
  "merlin",
  "num-traits",
@@ -6932,7 +6916,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -6941,7 +6925,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6951,7 +6935,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6962,7 +6946,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6979,7 +6963,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -6993,11 +6977,11 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "futures 0.3.16",
  "hash-db",
- "libsecp256k1 0.3.5",
+ "libsecp256k1 0.6.0",
  "log",
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -7018,7 +7002,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7029,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7046,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "ruzstd",
  "zstd",
@@ -7055,7 +7039,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7065,7 +7049,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "backtrace",
 ]
@@ -7073,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -7084,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7105,7 +7089,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7122,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.0.0",
@@ -7134,7 +7118,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "serde",
  "serde_json",
@@ -7143,7 +7127,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7156,7 +7140,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7166,7 +7150,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "hash-db",
  "log",
@@ -7189,12 +7173,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7207,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "log",
  "sp-core",
@@ -7220,7 +7204,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "futures-timer 3.0.2",
@@ -7237,7 +7221,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "erased-serde",
  "log",
@@ -7255,7 +7239,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -7264,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "log",
@@ -7279,7 +7263,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7293,7 +7277,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "futures 0.3.16",
  "futures-core",
@@ -7305,7 +7289,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7320,7 +7304,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate 1.0.0",
@@ -7332,7 +7316,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7369,16 +7353,6 @@ dependencies = [
  "nalgebra",
  "num-traits",
  "rand 0.8.4",
-]
-
-[[package]]
-name = "stream-cipher"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e15f898d8d8f25db24c253ea615cc14acf418ff307822995814e7d42cfa89"
-dependencies = [
- "block-cipher",
- "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -7478,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "platforms",
 ]
@@ -7486,7 +7460,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.16",
@@ -7509,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7523,7 +7497,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "async-trait",
  "futures 0.1.31",
@@ -7552,7 +7526,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "cfg-if 1.0.0",
  "frame-support",
@@ -7593,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "futures 0.3.16",
  "parity-scale-codec",
@@ -7630,7 +7604,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#676526a311c05d4c3dd174273561054efc99e456"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.10#6ddfb7182ee374b5c26c8320b2e77ba178160aef"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -8948,9 +8922,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]


### PR DESCRIPTION
This PR applies `cargo update sp-io` into the `polkadot-v0.9.10`.

The `polkadot-v0.9.10` in Substrate saw some changes so we need to update accordingly.