### PR TITLE
Remove optional `scale-info` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,7 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "sp-api",
  "sp-block-builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.1",
  "opaque-debug 0.3.0",
 ]
 
@@ -927,21 +927,21 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08493fa7707effc63254c66c6ea908675912493cd67952eda23c09fae2610b1"
+checksum = "fee7ad89dc1128635074c268ee661f90c3f7e83d9fd12910608c36b47d6c3412"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.1.5",
  "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.8.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6547abe025f4027edacd9edaa357aded014eecec42a5070d9b885c3c334aba2"
+checksum = "1580317203210c517b6d44794abfbe600698276db18127e37ad3e69bf5e848e5"
 dependencies = [
  "aead",
  "chacha20",
@@ -1071,6 +1071,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea47428dc9d2237f3c6bc134472edfd63ebba0af932e783506dcfd66f10d18a"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1675,7 +1684,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1693,7 +1702,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1701,6 +1710,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste",
+ "scale-info",
  "sp-api",
  "sp-io",
  "sp-runtime",
@@ -1712,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "Inflector",
  "chrono",
@@ -1738,11 +1748,12 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
+ "scale-info",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -1752,19 +1763,20 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "14.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96616f82e069102b95a72c87de4c84d2f87ef7f0f20630e78ce3824436483110"
 dependencies = [
+ "cfg-if 1.0.0",
  "parity-scale-codec",
+ "scale-info",
  "serde",
- "sp-core",
- "sp-std",
 ]
 
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1774,6 +1786,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "paste",
+ "scale-info",
  "serde",
  "smallvec",
  "sp-arithmetic",
@@ -1790,7 +1803,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1802,7 +1815,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.0.0",
@@ -1814,7 +1827,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1824,11 +1837,12 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-support",
  "log",
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "sp-core",
  "sp-io",
@@ -1840,12 +1854,13 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
+ "scale-info",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -1854,7 +1869,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1881,12 +1896,6 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -3732,11 +3741,11 @@ dependencies = [
 
 [[package]]
 name = "names"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
+checksum = "10a8690bf09abf659851e58cd666c3d37ac6af07c2bd7a9e332cfba471715775"
 dependencies = [
- "rand 0.3.23",
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -3914,12 +3923,13 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-timestamp",
  "parity-scale-codec",
+ "scale-info",
  "sp-application-crypto",
  "sp-consensus-aura",
  "sp-runtime",
@@ -3929,12 +3939,13 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
+ "scale-info",
  "sp-authorship",
  "sp-runtime",
  "sp-std",
@@ -3943,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3953,6 +3964,7 @@ dependencies = [
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
+ "scale-info",
  "sp-application-crypto",
  "sp-consensus-babe",
  "sp-consensus-vrf",
@@ -3966,13 +3978,14 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
  "parity-scale-codec",
+ "scale-info",
  "sp-runtime",
  "sp-std",
 ]
@@ -4024,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4033,6 +4046,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
+ "scale-info",
  "sp-application-crypto",
  "sp-core",
  "sp-finality-grandpa",
@@ -4046,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-benchmarking",
@@ -4054,6 +4068,7 @@ dependencies = [
  "frame-system",
  "pallet-mmr-primitives",
  "parity-scale-codec",
+ "scale-info",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -4063,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4079,12 +4094,13 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "safe-mix",
+ "scale-info",
  "sp-runtime",
  "sp-std",
 ]
@@ -4092,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4100,6 +4116,7 @@ dependencies = [
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
+ "scale-info",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -4112,11 +4129,12 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
+ "scale-info",
  "sp-io",
  "sp-runtime",
  "sp-std",
@@ -4125,13 +4143,14 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
  "parity-scale-codec",
+ "scale-info",
  "sp-inherents",
  "sp-io",
  "sp-runtime",
@@ -4142,11 +4161,12 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "smallvec",
  "sp-core",
@@ -4158,7 +4178,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4175,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4547,7 +4567,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.1",
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
@@ -4559,7 +4579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpufeatures 0.2.1",
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
@@ -4579,6 +4599,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-serde",
+ "scale-info",
  "uint",
 ]
 
@@ -4777,29 +4798,6 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -4843,21 +4841,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -4943,15 +4926,6 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -5171,16 +5145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruzstd"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cada0ef59efa6a5f4dc5e491f93d9f31e3fc7758df421ff1de8a706338e1100"
-dependencies = [
- "byteorder",
- "twox-hash",
-]
-
-[[package]]
 name = "rw-stream-sink"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5227,7 +5191,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "log",
  "sp-core",
@@ -5238,7 +5202,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -5261,7 +5225,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5277,7 +5241,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5293,7 +5257,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -5304,7 +5268,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -5342,7 +5306,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "fnv",
  "futures 0.3.17",
@@ -5370,7 +5334,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -5395,7 +5359,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -5419,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5448,7 +5412,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -5474,7 +5438,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "lazy_static",
  "libsecp256k1 0.6.0",
@@ -5500,9 +5464,10 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "derive_more",
+ "environmental",
  "parity-scale-codec",
  "pwasm-utils",
  "sc-allocator",
@@ -5517,7 +5482,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5533,7 +5498,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -5552,7 +5517,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5589,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.17",
@@ -5606,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5621,7 +5586,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -5639,7 +5604,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5690,7 +5655,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -5706,7 +5671,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5734,7 +5699,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -5761,7 +5726,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "futures 0.3.17",
  "libp2p",
@@ -5774,7 +5739,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5783,7 +5748,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "futures 0.3.17",
  "hash-db",
@@ -5814,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "futures 0.3.17",
  "jsonrpc-core",
@@ -5839,7 +5804,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "futures 0.3.17",
  "jsonrpc-core",
@@ -5850,12 +5815,13 @@ dependencies = [
  "log",
  "serde_json",
  "substrate-prometheus-endpoint",
+ "tokio",
 ]
 
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "directories",
@@ -5912,6 +5878,7 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "tempfile",
  "thiserror",
+ "tokio",
  "tracing",
  "tracing-futures",
 ]
@@ -5919,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5933,7 +5900,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "chrono",
  "futures 0.3.17",
@@ -5951,7 +5918,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -5980,7 +5947,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -5991,7 +5958,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "futures 0.3.17",
  "intervalier",
@@ -6018,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "derive_more",
  "futures 0.3.17",
@@ -6032,7 +5999,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -6051,6 +6018,7 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "scale-info-derive",
+ "serde",
 ]
 
 [[package]]
@@ -6212,9 +6180,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -6241,7 +6209,7 @@ checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpufeatures 0.2.1",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -6266,7 +6234,7 @@ checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpufeatures 0.2.1",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -6420,7 +6388,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "hash-db",
  "log",
@@ -6437,7 +6405,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.0.0",
@@ -6449,9 +6417,10 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "sp-core",
  "sp-io",
@@ -6461,11 +6430,12 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "integer-sqrt",
  "num-traits",
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "sp-debug-derive",
  "sp-std",
@@ -6475,7 +6445,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6487,7 +6457,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6499,7 +6469,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "futures 0.3.17",
  "log",
@@ -6517,7 +6487,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -6536,10 +6506,11 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
+ "scale-info",
  "sp-api",
  "sp-application-crypto",
  "sp-consensus",
@@ -6553,11 +6524,12 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "merlin",
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "sp-api",
  "sp-application-crypto",
@@ -6575,9 +6547,10 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "parity-scale-codec",
+ "scale-info",
  "sp-arithmetic",
  "sp-runtime",
 ]
@@ -6585,7 +6558,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6597,7 +6570,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6620,6 +6593,7 @@ dependencies = [
  "primitive-types",
  "rand 0.7.3",
  "regex",
+ "scale-info",
  "schnorrkel",
  "secrecy",
  "serde",
@@ -6641,7 +6615,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.2",
@@ -6650,7 +6624,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6660,7 +6634,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6671,11 +6645,12 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "finality-grandpa",
  "log",
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "sp-api",
  "sp-application-crypto",
@@ -6688,7 +6663,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -6702,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "futures 0.3.17",
  "hash-db",
@@ -6727,7 +6702,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6738,7 +6713,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6755,16 +6730,15 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
- "ruzstd",
  "zstd",
 ]
 
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6774,7 +6748,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "backtrace",
 ]
@@ -6782,7 +6756,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -6792,7 +6766,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6802,6 +6776,7 @@ dependencies = [
  "parity-util-mem",
  "paste",
  "rand 0.7.3",
+ "scale-info",
  "serde",
  "sp-application-crypto",
  "sp-arithmetic",
@@ -6813,7 +6788,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6830,7 +6805,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.0.0",
@@ -6842,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "serde",
  "serde_json",
@@ -6851,9 +6826,10 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "parity-scale-codec",
+ "scale-info",
  "sp-api",
  "sp-core",
  "sp-runtime",
@@ -6864,9 +6840,10 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "parity-scale-codec",
+ "scale-info",
  "sp-runtime",
  "sp-std",
 ]
@@ -6874,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "hash-db",
  "log",
@@ -6897,12 +6874,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -6915,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "log",
  "sp-core",
@@ -6928,7 +6905,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "futures-timer 3.0.2",
@@ -6944,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "erased-serde",
  "log",
@@ -6962,7 +6939,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -6971,11 +6948,12 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "log",
  "parity-scale-codec",
+ "scale-info",
  "sp-core",
  "sp-inherents",
  "sp-runtime",
@@ -6986,11 +6964,12 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "hash-db",
  "memory-db",
  "parity-scale-codec",
+ "scale-info",
  "sp-core",
  "sp-std",
  "trie-db",
@@ -7000,11 +6979,12 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "parity-wasm 0.42.2",
+ "scale-info",
  "serde",
  "sp-runtime",
  "sp-std",
@@ -7015,7 +6995,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -7026,7 +7006,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7153,7 +7133,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "platforms",
 ]
@@ -7161,7 +7141,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.17",
@@ -7183,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7197,7 +7177,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -7224,7 +7204,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "cfg-if 1.0.0",
  "frame-support",
@@ -7237,6 +7217,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "sc-service",
+ "scale-info",
  "serde",
  "sp-api",
  "sp-application-crypto",
@@ -7265,7 +7246,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "futures 0.3.17",
  "parity-scale-codec",
@@ -7301,7 +7282,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d73c37ecc16f4895c5f6ed5126d72af8cf87d9b3"
+source = "git+https://github.com/paritytech/substrate?branch=master#ba153b9ae050eda022f002d74d76f98d1e339a81"
 dependencies = [
  "ansi_term 0.12.1",
  "build-helper",
@@ -8395,9 +8376,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
 dependencies = [
  "zeroize_derive",
 ]

--- a/beefy-node/runtime/Cargo.toml
+++ b/beefy-node/runtime/Cargo.toml
@@ -22,6 +22,7 @@ version = "2.0.0"
 
 [dependencies]
 hex-literal = { optional = true, version = "0.3" }
+scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], optional = true, version = "1.0.130" }
 
 # local dependencies

--- a/beefy-node/runtime/src/lib.rs
+++ b/beefy-node/runtime/src/lib.rs
@@ -376,7 +376,7 @@ impl_runtime_apis! {
 
 	impl sp_api::Metadata<Block> for Runtime {
 		fn metadata() -> OpaqueMetadata {
-			Runtime::metadata().into()
+			OpaqueMetadata::new(Runtime::metadata().into())
 		}
 	}
 

--- a/beefy-primitives/Cargo.toml
+++ b/beefy-primitives/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }
-scale-info = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 
 sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
@@ -24,6 +24,7 @@ sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "maste
 default = ["std"]
 std = [
 	"codec/std",
+	"scale-info/std",
 	"sp-api/std",
 	"sp-application-crypto/std",
 	"sp-core/std",

--- a/beefy-primitives/src/lib.rs
+++ b/beefy-primitives/src/lib.rs
@@ -39,6 +39,7 @@ pub mod witness;
 pub use commitment::{Commitment, SignedCommitment, VersionedCommitment};
 
 use codec::{Codec, Decode, Encode};
+use scale_info::TypeInfo;
 use sp_core::H256;
 use sp_std::prelude::*;
 

--- a/beefy-primitives/src/lib.rs
+++ b/beefy-primitives/src/lib.rs
@@ -78,8 +78,7 @@ pub const GENESIS_AUTHORITY_SET_ID: u64 = 0;
 pub type ValidatorSetId = u64;
 
 /// A set of BEEFY authorities, a.k.a. validators.
-#[derive(Decode, Encode, Debug, PartialEq, Clone)]
-#[cfg_attr(feature = "scale-info", derive(scale_info::TypeInfo))]
+#[derive(Decode, Encode, Debug, PartialEq, Clone, TypeInfo)]
 pub struct ValidatorSet<AuthorityId> {
 	/// Public keys of the validator set elements
 	pub validators: Vec<AuthorityId>,
@@ -104,8 +103,7 @@ pub type AuthorityIndex = u32;
 pub type MmrRootHash = H256;
 
 /// A consensus log item for BEEFY.
-#[derive(Decode, Encode)]
-#[cfg_attr(feature = "scale-info", derive(scale_info::TypeInfo))]
+#[derive(Decode, Encode, TypeInfo)]
 pub enum ConsensusLog<AuthorityId: Codec> {
 	/// The authorities have changed.
 	#[codec(index = 1)]
@@ -122,8 +120,7 @@ pub enum ConsensusLog<AuthorityId: Codec> {
 ///
 /// A vote message is a direct vote created by a BEEFY node on every voting round
 /// and is gossiped to its peers.
-#[derive(Debug, Decode, Encode)]
-#[cfg_attr(feature = "scale-info", derive(scale_info::TypeInfo))]
+#[derive(Debug, Decode, Encode, TypeInfo)]
 pub struct VoteMessage<Hash, Number, Id, Signature> {
 	/// Commit to information extracted from a finalized block
 	pub commitment: Commitment<Number, Hash>,

--- a/beefy-primitives/src/mmr.rs
+++ b/beefy-primitives/src/mmr.rs
@@ -26,6 +26,7 @@
 //! or are completely standalone, but heavily inspired by Polkadot.
 
 use codec::{Decode, Encode};
+use scale_info::TypeInfo;
 
 /// A standard leaf that gets added every block to the MMR constructed by Substrate's `pallet_mmr`.
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]

--- a/beefy-primitives/src/mmr.rs
+++ b/beefy-primitives/src/mmr.rs
@@ -79,8 +79,7 @@ impl MmrLeafVersion {
 }
 
 /// Details of the next BEEFY authority set.
-#[derive(Debug, Default, PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "scale-info", derive(scale_info::TypeInfo))]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Encode, Decode, TypeInfo)]
 pub struct BeefyNextAuthoritySet<MerkleRoot> {
 	/// Id of the next set.
 	///


### PR DESCRIPTION
Following up on https://github.com/paritytech/grandpa-bridge-gadget/pull/218#issuecomment-889756176, now that https://github.com/paritytech/substrate/pull/8615 has been merged.

Required to make CI happy at the time. Will require removing the usage of the feature in `polkadot`. PR https://github.com/paritytech/polkadot/pull/3336