### PR TITLE
Prune .git suffix from some dependencies

### DIFF
--- a/beefy-mmr-pallet/Cargo.toml
+++ b/beefy-mmr-pallet/Cargo.toml
@@ -29,7 +29,7 @@ beefy-primitives = { path = "../beefy-primitives", default-features = false }
 pallet-beefy = { path = "../beefy-pallet", default-features = false }
 
 [dev-dependencies]
-sp-staking = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master" }
 hex = "0.4"
 hex-literal = "0.3"
 

--- a/beefy-pallet/Cargo.toml
+++ b/beefy-pallet/Cargo.toml
@@ -21,9 +21,9 @@ pallet-session = { git = "https://github.com/paritytech/substrate", default-feat
 beefy-primitives = { path = "../beefy-primitives", default-features = false }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-staking = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
 default = ["std"]

--- a/beefy-test/Cargo.toml
+++ b/beefy-test/Cargo.toml
@@ -9,15 +9,15 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 sc-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-network = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
-substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-substrate-test-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-test-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 beefy-gadget = { path = "../beefy-gadget" }
 beefy-primitives = { path = "../beefy-primitives" }
@@ -32,4 +32,4 @@ strum = { version = "0.21", features = ["derive"] }
 tokio = { version = "1.10", features = ["full"] }
 
 [dev-dependencies]
-sp-tracing = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "master" }


### PR DESCRIPTION
This small PR makes the `Cargo.toml` files more consistent with each other by removing the `.git` suffix from the few dependencies that included it. This makes no functional changes, but it makes it easier to change the dependency branch with scripts or search and replace.