### PR TITLE
Ignore BEEFY deps for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,9 @@ updates:
   - dependency-name: substrate-*
     versions:
     - ">= 0"
+  - dependency-name: beefy-*
+    versions:
+    - ">= 0"
   - dependency-name: serde_json
     versions:
     - 1.0.62


### PR DESCRIPTION
Since we update Substrate dependencies manually anyway ignore them in @dependabot.