### PR TITLE
Add GHA to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,7 @@ updates:
     versions:
     - 1.0.62
   rebase-strategy: disabled
+- package-ecosystem: github-actions
+  directory: '/'
+  schedule:
+    interval: daily


### PR DESCRIPTION
This PR adds GitHub Actions monitoring to the Dependabot

Related issues:
https://github.com/paritytech/ci_cd/issues/407
https://github.com/paritytech/ci_cd/issues/464