### PR TITLE
Pin gha versions

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on:            ubuntu-latest
     steps:
       - name:           Cancel Previous Runs
-        uses:           styfle/cancel-workflow-action@0.9.1
+        uses:           styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7 # 0.10.0
         with:
           access_token: ${{ github.token }}
       - name:           Checkout sources & submodules
-        uses:           actions/checkout@master
+        uses:           actions/checkout@v3
         with:
           fetch-depth:  5
           submodules:   recursive

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,18 +18,18 @@ jobs:
       RUST_BACKTRACE:   full
     steps:
       - name:           Cancel Previous Runs
-        uses:           styfle/cancel-workflow-action@0.9.1
+        uses:           styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7 # 0.10.0
         with:
           access_token: ${{ github.token }}
       - name:           Checkout sources & submodules
-        uses:           actions/checkout@master
+        uses:           actions/checkout@v3
         with:
           fetch-depth:  5
           submodules:   recursive
       - name:           Add rustfmt
         run:            rustup component add rustfmt
       - name:           rust-fmt check
-        uses:           actions-rs/cargo@master
+        uses:           actions-rs/cargo@v1
         with:
           command:      fmt
           args:         --all -- --check --config merge_imports=true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,11 +18,11 @@ jobs:
       NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
-        uses:                      styfle/cancel-workflow-action@0.9.1
+        uses:                      styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7 # 0.10.0
         with:
           access_token:            ${{ github.token }}
       - name:                      Checkout sources & submodules
-        uses:                      actions/checkout@master
+        uses:                      actions/checkout@v3
         with:
           fetch-depth:             5
           submodules:              recursive
@@ -32,7 +32,7 @@ jobs:
         run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
 ## Build Stage
       - name:                      Building rust-stable
-        uses:                      actions-rs/cargo@master
+        uses:                      actions-rs/cargo@v1
         if:                        github.ref == 'refs/heads/master'
         with:
           command:                 build
@@ -47,11 +47,11 @@ jobs:
       NIGHTLY: nightly
     steps:
       - name:                      Cancel Previous Runs
-        uses:                      styfle/cancel-workflow-action@0.9.1
+        uses:                      styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7 # 0.10.0
         with:
           access_token:            ${{ github.token }}
       - name:                      Checkout sources & submodules
-        uses:                      actions/checkout@master
+        uses:                      actions/checkout@v3
         with:
           fetch-depth:             5
           submodules:              recursive
@@ -61,7 +61,7 @@ jobs:
         run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
 ## Check Stage
       - name:                      Checking rust-stable
-        uses:                      actions-rs/cargo@master
+        uses:                      actions-rs/cargo@v1
         with:
           command:                 check
           toolchain:               stable
@@ -69,7 +69,7 @@ jobs:
 
 ## Test Stage
       - name:                      Testing rust-stable
-        uses:                      actions-rs/cargo@master
+        uses:                      actions-rs/cargo@v1
         with:
           command:                 test
           toolchain:               stable


### PR DESCRIPTION
In order to improve our security posture with GitHub Actions usage. I've made a version pinning ether to commit hash or to specific version.

Related issues and policy:
https://github.com/paritytech/ci_cd/issues/464
https://github.com/paritytech/ci_cd/wiki/Policies-and-regulations:-GitHub-Actions-usage-policies